### PR TITLE
Number sequence option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@ atlassian-ide-plugin.xml
 .classpath
 .project
 .settings
-
-# Allow this directory to be empty
-!src/test/java/org/apache/ibatis/migration/commands/scripts

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ atlassian-ide-plugin.xml
 .classpath
 .project
 .settings
+
+# Allow this directory to be empty
+!src/test/java/org/apache/ibatis/migration/commands/scripts

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install MyBatis Migrations ${project.version} (${implementation.build})
   
   See the reference documentation here http://mybatis.github.io/migrations/
 
-## Windows
+### Windows
 
   [1] Unzip the distribution archive, i.e. mybatis-${project.version}-migrations.zip to the directory you wish
       to install MyBatis Migrations.
@@ -33,7 +33,7 @@ Install MyBatis Migrations ${project.version} (${implementation.build})
   [4] In the same dialog, update/create the Path environment variable in the user variables and prepend the value
       %MIGRATIONS% to add MyBatis Migrations available in the command line.
 
-## Unix-based Operating Systems (Linux, Solaris and Mac OS X)
+### Unix-based Operating Systems (Linux, Solaris and Mac OS X)
 
   [1] Extract the distribution archive, i.e. mybatis-${project.version}-migrations.zip to the directory you wish to
       install MyBatis Migrations. These instructions assume you chose

--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -1,35 +1,21 @@
 package org.apache.ibatis.migration.commands;
 
-import static org.apache.ibatis.migration.utils.Util.*;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.LineNumberReader;
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
-import java.util.TimeZone;
-
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.ExternalResources;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.migration.ConnectionProvider;
-import org.apache.ibatis.migration.DataSourceConnectionProvider;
-import org.apache.ibatis.migration.FileMigrationLoader;
-import org.apache.ibatis.migration.MigrationException;
-import org.apache.ibatis.migration.MigrationLoader;
+import org.apache.ibatis.migration.*;
 import org.apache.ibatis.migration.options.DatabaseOperationOption;
 import org.apache.ibatis.migration.options.SelectedOptions;
 import org.apache.ibatis.migration.options.SelectedPaths;
 import org.apache.ibatis.parsing.PropertyParser;
+
+import java.io.*;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static org.apache.ibatis.migration.utils.Util.file;
 
 public abstract class BaseCommand implements Command {
   private static final String DATE_FORMAT = "yyyyMMddHHmmss";
@@ -68,6 +54,10 @@ public abstract class BaseCommand implements Command {
   }
 
   protected String getNextIDAsString() {
+    return getNextTimestampIDAsString();
+  }
+
+  protected String getNextTimestampIDAsString() {
     try {
       // Ensure that two subsequent calls are less likely to return the same value.
       Thread.sleep(1000);

--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -84,7 +84,12 @@ public abstract class BaseCommand implements Command {
   }
 
   private Integer sequenceNumberOfFile(String fileName) {
-    return Integer.valueOf(fileName.substring(0, fileName.indexOf("_")));
+    try {
+      return Integer.valueOf(fileName.substring(0, fileName.indexOf("_")));
+    } catch (StringIndexOutOfBoundsException e) {
+      // File does not have any numbers. Will ignore this and make this the same as the initial number
+      return getDatabaseOperationOption().getInitialSequence() - 1;
+    }
   }
 
   protected String getNextTimestampIDAsString() {

--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -252,7 +252,9 @@ public abstract class BaseCommand implements Command {
     String delimiterString = props.getProperty("delimiter");
     option.setDelimiter(delimiterString == null ? ";" : delimiterString);
     option.setUseSequenceNumber(Boolean.valueOf(props.getProperty("useSequenceNumber")));
-    option.setInitialSequence(Integer.valueOf(props.getProperty("initialSequence")));
+    if (option.useSequenceNumber()) {
+      option.setInitialSequence(Integer.valueOf(props.getProperty("initialSequence")));
+    }
     return option;
   }
 }

--- a/src/main/java/org/apache/ibatis/migration/commands/NewCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/NewCommand.java
@@ -12,7 +12,7 @@ public final class NewCommand extends BaseCommand {
 
   private static final String MIGRATIONS_HOME = "MIGRATIONS_HOME";
   private static final String MIGRATIONS_HOME_PROPERTY = "migrationHome";
-  private static final String CUSTOM_NEW_COMMAND_TEMPATE_PROPERTY = "new_command.template";
+  private static final String CUSTOM_NEW_COMMAND_TEMPLATE_PROPERTY = "new_command.template";
   private static final String MIGRATIONS_PROPERTIES = "migration.properties";
 
   public NewCommand(SelectedOptions options) {
@@ -43,7 +43,7 @@ public final class NewCommand extends BaseCommand {
         //get template name from properties file
         final String customConfiguredTemplate =
             ExternalResources.getConfiguredTemplate(migrationsHome + "/" + MIGRATIONS_PROPERTIES,
-                CUSTOM_NEW_COMMAND_TEMPATE_PROPERTY);
+                                                       CUSTOM_NEW_COMMAND_TEMPLATE_PROPERTY);
         copyExternalResourceTo(migrationsHome + "/" + customConfiguredTemplate,
             Util.file(paths.getScriptPath(), filename));
       } catch (FileNotFoundException e) {

--- a/src/main/java/org/apache/ibatis/migration/options/DatabaseOperationOption.java
+++ b/src/main/java/org/apache/ibatis/migration/options/DatabaseOperationOption.java
@@ -21,6 +21,10 @@ public class DatabaseOperationOption {
 
   private String delimiter;
 
+  private boolean useSequenceNumber = false;
+
+  private Integer initialSequence;
+
   public String getChangelogTable() {
     return changelogTable == null ? DEFAULT_CHANGELOG_TABLE : changelogTable;
   }
@@ -83,5 +87,21 @@ public class DatabaseOperationOption {
 
   public void setDelimiter(String delimiter) {
     this.delimiter = delimiter;
+  }
+
+  public void setUseSequenceNumber(boolean useSequenceNumber) {
+    this.useSequenceNumber = useSequenceNumber;
+  }
+
+  public boolean useSequenceNumber() {
+      return useSequenceNumber;
+  }
+
+  public void setInitialSequence(Integer initialSequence) {
+    this.initialSequence = initialSequence;
+  }
+
+  public Integer getInitialSequence() {
+    return initialSequence;
   }
 }

--- a/src/main/java/org/apache/ibatis/migration/options/SelectedOptions.java
+++ b/src/main/java/org/apache/ibatis/migration/options/SelectedOptions.java
@@ -14,6 +14,10 @@ public class SelectedOptions {
     return paths;
   }
 
+  public void setPaths(SelectedPaths paths) {
+    this.paths = paths;
+  }
+
   public String getEnvironment() {
     return environment;
   }

--- a/src/test/java/org/apache/ibatis/migration/commands/NewCommandTest.java
+++ b/src/test/java/org/apache/ibatis/migration/commands/NewCommandTest.java
@@ -1,0 +1,37 @@
+package org.apache.ibatis.migration.commands;
+
+import org.apache.ibatis.migration.MigrationException;
+import org.apache.ibatis.migration.options.SelectedOptions;
+import org.apache.ibatis.migration.options.SelectedPaths;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+public class NewCommandTest {
+  private SelectedOptions newSelectedOption;
+  private SelectedPaths selectedPaths;
+
+  @Before
+  public void setup() {
+    selectedPaths = new SelectedPaths();
+    selectedPaths.setBasePath(new File("src/test/java/org/apache/ibatis/migration/commands"));
+
+    newSelectedOption = new SelectedOptions();
+    newSelectedOption.setCommand("New");
+    newSelectedOption.setPaths(selectedPaths);
+  }
+
+  @Test
+  (expected = MigrationException.class)
+  public void testThrowsExceptionWhenDescriptionIsNotSupplied() {
+    NewCommand newCommand = new NewCommand(newSelectedOption);
+    newCommand.execute("");
+  }
+
+  @Test
+  public void testSpacesInDescriptionIsReplacedWithUnderscores() {
+    NewCommand newCommand = new NewCommand(newSelectedOption);
+    newCommand.execute("must be underscores instead of spaces between words");
+  }
+}

--- a/src/test/java/org/apache/ibatis/migration/commands/NewCommandTest.java
+++ b/src/test/java/org/apache/ibatis/migration/commands/NewCommandTest.java
@@ -8,8 +8,10 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class NewCommandTest {
   private SelectedOptions newSelectedOption;
@@ -82,5 +84,19 @@ public class NewCommandTest {
         for (File file : selectedPaths.getScriptPath().listFiles()) {
             file.delete();
         }
+    }
+
+    @Test
+    public void testScriptsDirWithOnlyBootstrapFileWhichHasNoSequenceNumber() throws IOException {
+      File bootStrapFile = new File(selectedPaths.getScriptPath() + "/bootstrap.sql");
+      bootStrapFile.createNewFile();
+      assertTrue(bootStrapFile.exists());
+
+      newSelectedOption.setEnvironment("development_useSeqNum");
+      NewCommand newCommand = new NewCommand(newSelectedOption);
+
+      assertEquals("1", newCommand.getNextIDAsString());
+
+      bootStrapFile.delete();
     }
 }

--- a/src/test/java/org/apache/ibatis/migration/commands/NewCommandTest.java
+++ b/src/test/java/org/apache/ibatis/migration/commands/NewCommandTest.java
@@ -7,6 +7,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FilenameFilter;
+
+import static org.junit.Assert.assertEquals;
 
 public class NewCommandTest {
   private SelectedOptions newSelectedOption;
@@ -33,5 +36,51 @@ public class NewCommandTest {
   public void testSpacesInDescriptionIsReplacedWithUnderscores() {
     NewCommand newCommand = new NewCommand(newSelectedOption);
     newCommand.execute("must be underscores instead of spaces between words");
+
+    File[] files = selectedPaths.getScriptPath().listFiles(new FilenameFilter() {
+        @Override
+        public boolean accept(File dir, String name) {
+            return name.contains("must_be_underscores_instead_of_spaces_between_words.sql");
+        }
+    });
+
+    assertEquals(1, files.length);
+    files[0].delete();
   }
+
+    @Test
+    public void testNewFileStartsWithNumberSeqence() {
+      newSelectedOption.setEnvironment("development_useSeqNum");
+
+      NewCommand newCommand = new NewCommand(newSelectedOption);
+      newCommand.execute("should start with one");
+
+      File[] files = selectedPaths.getScriptPath().listFiles(new FilenameFilter() {
+        @Override
+        public boolean accept(File dir, String name) {
+            return name.indexOf("1")==0;
+        }
+      });
+
+      assertEquals(1, files.length);
+      files[0].delete();
+    }
+
+    @Test
+    public void testSequenceNumberIncrementedOnEachNewCommand() {
+        newSelectedOption.setEnvironment("development_useSeqNum");
+
+        NewCommand newCommand = new NewCommand(newSelectedOption);
+
+        newCommand.execute("one");
+        newCommand.execute("two");
+        newCommand.execute("three");
+
+        assertEquals("4", newCommand.getNextIDAsString());
+
+        // cleaning up after the test
+        for (File file : selectedPaths.getScriptPath().listFiles()) {
+            file.delete();
+        }
+    }
 }

--- a/src/test/java/org/apache/ibatis/migration/commands/NewCommandTest.java
+++ b/src/test/java/org/apache/ibatis/migration/commands/NewCommandTest.java
@@ -82,7 +82,9 @@ public class NewCommandTest {
 
         // cleaning up after the test
         for (File file : selectedPaths.getScriptPath().listFiles()) {
-            file.delete();
+            if (!file.getName().equals(".gitignore")) {
+              file.delete();
+            }
         }
     }
 

--- a/src/test/java/org/apache/ibatis/migration/commands/environments/development.properties
+++ b/src/test/java/org/apache/ibatis/migration/commands/environments/development.properties
@@ -5,17 +5,18 @@ time_zone=GMT+0:00
 # script_char_set=UTF-8
 
 ## JDBC connection properties.
-driver=
-url=
+driver=org.apache.derby.jdbc.EmbeddedDriver
+url=jdbc:derby:ibderby;create=true
 username=
 password=
 
 #
 # A NOTE ON STORED PROCEDURES AND DELIMITERS
 #
-# Stored procedures and functions commonly have nested delimiters
-# that conflict with the schema migration parsing.  If you tend
-# to use procs, functions, triggers or anything that could create
+# Stored procedures and
+# functions commonly have nested delimiters that conflict
+# with the schema migration parsing.  If you tend to use
+# procs, functions, triggers or anything that could create
 # this situation, then you may want to experiment with
 # send_full_script=true (preferred), or if you can't use
 # send_full_script, then you may have to resort to a full
@@ -30,7 +31,7 @@ password=
 # simply sends the entire script at once.
 # Use with JDBC drivers that can accept large
 # blocks of delimited text at once.
-send_full_script=true
+send_full_script=false
 
 # This controls how statements are delimited.
 # By default statements are delimited by an

--- a/src/test/java/org/apache/ibatis/migration/commands/environments/development_useSeqNum.properties
+++ b/src/test/java/org/apache/ibatis/migration/commands/environments/development_useSeqNum.properties
@@ -65,5 +65,5 @@ changelog=CHANGELOG
 
 # Use number sequence instead of timezone
 # If set to true, it will start with initialSequence. Each new command will increment sequence by 1
-useSequenceNumber=false
+useSequenceNumber=true
 initialSequence=1

--- a/src/test/java/org/apache/ibatis/migration/commands/scripts/.gitignore
+++ b/src/test/java/org/apache/ibatis/migration/commands/scripts/.gitignore
@@ -1,0 +1,1 @@
+# Created by .ignore support plugin (hsz.mobi)

--- a/src/test/java/org/apache/ibatis/migration/commands/scripts/20150305223427_must_be_underscores_instead_of_spaces_between_words.sql
+++ b/src/test/java/org/apache/ibatis/migration/commands/scripts/20150305223427_must_be_underscores_instead_of_spaces_between_words.sql
@@ -1,9 +1,0 @@
--- // must be underscores instead of spaces between words
--- Migration SQL that makes the change goes here.
-
-
-
--- //@UNDO
--- SQL to undo the change goes here.
-
-

--- a/src/test/java/org/apache/ibatis/migration/commands/scripts/20150305223427_must_be_underscores_instead_of_spaces_between_words.sql
+++ b/src/test/java/org/apache/ibatis/migration/commands/scripts/20150305223427_must_be_underscores_instead_of_spaces_between_words.sql
@@ -1,0 +1,9 @@
+-- // must be underscores instead of spaces between words
+-- Migration SQL that makes the change goes here.
+
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
Tracks sql scripts with sequential numbers instead of timestamp.
This addresses the non-timestamp sequence issue

e.g. 

1_first_file.sql
2_second_file.sql
