### PR TITLE
Status command indicates missing scripts

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/Change.java
+++ b/src/main/java/org/apache/ibatis/migration/Change.java
@@ -70,7 +70,9 @@ public class Change implements Comparable<Change> {
   }
 
   public String toString() {
-    return id + " " + (appliedTimestamp == null ? "   ...pending...   " : appliedTimestamp) + " " + description;
+    String status = appliedTimestamp == null ? "   ...pending...   " : appliedTimestamp;
+    String message = filename == null ? " ...missing script... " : " ";
+    return id + " " + status + message + description;
   }
 
   public boolean equals(Object o) {

--- a/src/main/java/org/apache/ibatis/migration/operations/StatusOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/StatusOperation.java
@@ -73,6 +73,7 @@ public final class StatusOperation extends DatabaseOperation<StatusOperation> {
     for (Change change : changelog) {
       if (migrations.indexOf(change) < 0) {
         missingScript++;
+        applied++;
         merged.add(change);
       }
     }

--- a/src/main/java/org/apache/ibatis/migration/operations/StatusOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/StatusOperation.java
@@ -83,6 +83,10 @@ public final class StatusOperation extends DatabaseOperation<StatusOperation> {
     return applied;
   }
 
+  public int getMissingScriptCount() {
+	  return missingScript;
+  }
+
   public int getPendingCount() {
     return pending;
   }

--- a/src/main/java/org/apache/ibatis/migration/operations/StatusOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/StatusOperation.java
@@ -45,8 +45,7 @@ public final class StatusOperation extends DatabaseOperation<StatusOperation> {
     if (changelogExists(connectionProvider, option)) {
       changes = mergeWithChangelog(migrations, getChangelog(connectionProvider, option));
     } else {
-      changes = new ArrayList<Change>();
-      changes.addAll(migrations);
+      changes = new ArrayList<Change>(migrations);
       pending = migrations.size();
     }
     Collections.sort(changes);


### PR DESCRIPTION
Add some text in the status command's description field to indicate if a script file is not found in the file system. This can happen, for example, when running status on a database when the local environment is on a branch that does not include one of the migrations previously applied to the database from a different branch.
