### PR TITLE
Made migrations Hive compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>26-SNAPSHOT</version>
+    <version>26</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>26-SNAPSHOT</version>
+    <version>27-SNAPSHOT</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>27-SNAPSHOT</version>
+    <version>26-SNAPSHOT</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/org/apache/ibatis/migration/Change.java
+++ b/src/main/java/org/apache/ibatis/migration/Change.java
@@ -15,11 +15,10 @@
  */
 package org.apache.ibatis.migration;
 
-import java.math.BigDecimal;
 
 public class Change implements Comparable<Change> {
 
-  private BigDecimal id;
+  private Long id;
   private String description;
   private String appliedTimestamp;
   private String filename;
@@ -27,21 +26,21 @@ public class Change implements Comparable<Change> {
   public Change() {
   }
 
-  public Change(BigDecimal id) {
+  public Change(Long id) {
     this.id = id;
   }
 
-  public Change(BigDecimal id, String appliedTimestamp, String description) {
+  public Change(Long id, String appliedTimestamp, String description) {
     this.id = id;
     this.appliedTimestamp = appliedTimestamp;
     this.description = description;
   }
 
-  public BigDecimal getId() {
+  public Long getId() {
     return id;
   }
 
-  public void setId(BigDecimal id) {
+  public void setId(Long id) {
     this.id = id;
   }
 

--- a/src/main/java/org/apache/ibatis/migration/FileMigrationLoader.java
+++ b/src/main/java/org/apache/ibatis/migration/FileMigrationLoader.java
@@ -18,7 +18,6 @@ package org.apache.ibatis.migration;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -64,7 +63,7 @@ public class FileMigrationLoader implements MigrationLoader {
       Change change = new Change();
       int lastIndexOfDot = filename.lastIndexOf(".");
       String[] parts = filename.substring(0, lastIndexOfDot).split("_");
-      change.setId(new BigDecimal(parts[0]));
+      change.setId(Long.valueOf(parts[0]));
       StringBuilder builder = new StringBuilder();
       for (int i = 1; i < parts.length; i++) {
         if (i > 1) {

--- a/src/main/java/org/apache/ibatis/migration/MigrationScript.java
+++ b/src/main/java/org/apache/ibatis/migration/MigrationScript.java
@@ -15,14 +15,13 @@
  */
 package org.apache.ibatis.migration;
 
-import java.math.BigDecimal;
 
 public interface MigrationScript {
   /**
    * @return ID of this migration script.<br>
    *         Newer script should have a larger ID number.
    */
-  BigDecimal getId();
+  Long getId();
 
   /**
    * @return Short description of this migration script.

--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -15,7 +15,7 @@
  */
 package org.apache.ibatis.migration.commands;
 
-import static org.apache.ibatis.migration.utils.Util.*;
+import static org.apache.ibatis.migration.utils.Util.file;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -72,14 +72,6 @@ public abstract class BaseCommand implements Command {
 
   protected boolean paramsEmpty(String... params) {
     return params == null || params.length < 1 || params[0] == null || params[0].length() < 1;
-  }
-
-  protected String changelogTable() {
-    String changelog = environmentProperties().getProperty("changelog");
-    if (changelog == null) {
-      changelog = "CHANGELOG";
-    }
-    return changelog;
   }
 
   protected String getNextIDAsString() {
@@ -235,9 +227,11 @@ public abstract class BaseCommand implements Command {
   }
 
   protected DatabaseOperationOption getDatabaseOperationOption() {
+	Properties props = environmentProperties();
     DatabaseOperationOption option = new DatabaseOperationOption();
-    option.setChangelogTable(changelogTable());
-    Properties props = environmentProperties();
+    option.setChangelogTable(props.getProperty("changelog"));
+    option.setChangelogInsert(props.getProperty("changelog_insert"));
+    option.setChangelogDelete(props.getProperty("changelog_delete"));
     option.setStopOnError(!options.isForce());
     option.setEscapeProcessing(false);
     option.setAutoCommit(Boolean.valueOf(props.getProperty("auto_commit")));

--- a/src/main/java/org/apache/ibatis/migration/commands/ScriptCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/ScriptCommand.java
@@ -17,7 +17,6 @@ package org.apache.ibatis.migration.commands;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -44,8 +43,8 @@ public final class ScriptCommand extends BaseCommand {
       if (parser.countTokens() != 2) {
         throw new MigrationException("The script command requires a range of versions from v1 - v2.");
       }
-      BigDecimal v1 = new BigDecimal(parser.nextToken());
-      BigDecimal v2 = new BigDecimal(parser.nextToken());
+      Long v1 = Long.valueOf(parser.nextToken());
+      Long v2 = Long.valueOf(parser.nextToken());
       int comparison = v1.compareTo(v2);
       if (comparison == 0) {
         throw new MigrationException("The script command requires two different versions. Use 0 to include the first version.");
@@ -91,8 +90,8 @@ public final class ScriptCommand extends BaseCommand {
     return "DELETE FROM " + changelogTable() + " WHERE ID = " + change.getId() + getDelimiter();
   }
 
-  private boolean shouldRun(Change change, BigDecimal v1, BigDecimal v2) {
-    BigDecimal id = change.getId();
+  private boolean shouldRun(Change change, Long v1, Long v2) {
+    Long id = change.getId();
     if (v1.compareTo(v2) > 0) {
       return (id.compareTo(v2) > 0 && id.compareTo(v1) <= 0);
     } else {

--- a/src/main/java/org/apache/ibatis/migration/commands/ScriptCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/ScriptCommand.java
@@ -81,13 +81,17 @@ public final class ScriptCommand extends BaseCommand {
   }
 
   private String generateVersionInsert(Change change) {
-    return "INSERT INTO " + changelogTable() + " (ID, APPLIED_AT, DESCRIPTION) " +
-        "VALUES (" + change.getId() + ", '" + DatabaseOperation.generateAppliedTimeStampAsString() + "', '"
-        + change.getDescription().replace('\'', ' ') + "')" + getDelimiter();
+	String changelogInsert = getDatabaseOperationOption().getChangelogInsert();
+	String values = change.getId() + ", '" + DatabaseOperation.generateAppliedTimeStampAsString() + "', '"
+	        + change.getDescription().replace('\'', ' ') + "'";
+    return changelogInsert.replace("${changelog}", getDatabaseOperationOption().getChangelogTable())
+    		.replace("?,?,?", values) + getDelimiter();
   }
 
   private String generateVersionDelete(Change change) {
-    return "DELETE FROM " + changelogTable() + " WHERE ID = " + change.getId() + getDelimiter();
+	String changelogDelete = getDatabaseOperationOption().getChangelogDelete();
+    return changelogDelete.replace("${changelog}", getDatabaseOperationOption().getChangelogTable())
+    		.replace("?", Long.toString(change.getId())) + getDelimiter();
   }
 
   private boolean shouldRun(Change change, Long v1, Long v2) {

--- a/src/main/java/org/apache/ibatis/migration/commands/VersionCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/VersionCommand.java
@@ -31,7 +31,7 @@ public final class VersionCommand extends BaseCommand {
     ensureParamsPassed(params);
     ensureNumericParam(params);
 
-    VersionOperation operation = new VersionOperation(new BigDecimal(params[0]));
+    VersionOperation operation = new VersionOperation(Long.valueOf(params[0]));
     operation.operate(getConnectionProvider(), getMigrationLoader(), getDatabaseOperationOption(), printStream);
   }
 

--- a/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
@@ -17,7 +17,6 @@ package org.apache.ibatis.migration.operations;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -62,7 +61,7 @@ public abstract class DatabaseOperation<T extends DatabaseOperation<T>> {
         String id = change.get("ID") == null ? null : change.get("ID").toString();
         String appliedAt = change.get("APPLIED_AT") == null ? null : change.get("APPLIED_AT").toString();
         String description = change.get("DESCRIPTION") == null ? null : change.get("DESCRIPTION").toString();
-        changes.add(new Change(new BigDecimal(id), appliedAt, description));
+        changes.add(new Change(Long.valueOf(id), appliedAt, description));
       }
       return changes;
     } catch (SQLException e) {

--- a/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
@@ -39,7 +39,9 @@ public abstract class DatabaseOperation<T extends DatabaseOperation<T>> {
     SqlRunner runner = getSqlRunner(connectionProvider);
     change.setAppliedTimestamp(generateAppliedTimeStampAsString());
     try {
-      runner.insert("insert into " + option.getChangelogTable() + " (ID, APPLIED_AT, DESCRIPTION) values (?,?,?)", change.getId(), change.getAppliedTimestamp(), change.getDescription());
+      String changelogInsert = option.getChangelogInsert();
+      runner.insert(changelogInsert.replace("${changelog}", option.getChangelogTable()), 
+    		  change.getId(), change.getAppliedTimestamp(), change.getDescription());
     } catch (SQLException e) {
       throw new MigrationException("Error querying last applied migration.  Cause: " + e, e);
     } finally {

--- a/src/main/java/org/apache/ibatis/migration/operations/DownOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DownOperation.java
@@ -87,7 +87,8 @@ public final class DownOperation extends DatabaseOperation<DownOperation> {
   protected void deleteChange(ConnectionProvider connectionProvider, Change change, DatabaseOperationOption option) {
     SqlRunner runner = getSqlRunner(connectionProvider);
     try {
-      runner.delete("delete from " + option.getChangelogTable() + " where id = ?", change.getId());
+      String changelogDelete = option.getChangelogDelete();
+      runner.delete(changelogDelete.replace("${changelog}", option.getChangelogTable()), change.getId());
     } catch (SQLException e) {
       throw new MigrationException("Error querying last applied migration.  Cause: " + e, e);
     } finally {

--- a/src/main/java/org/apache/ibatis/migration/operations/VersionOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/VersionOperation.java
@@ -16,7 +16,6 @@
 package org.apache.ibatis.migration.operations;
 
 import java.io.PrintStream;
-import java.math.BigDecimal;
 import java.util.List;
 
 import org.apache.ibatis.migration.Change;
@@ -26,9 +25,9 @@ import org.apache.ibatis.migration.MigrationLoader;
 import org.apache.ibatis.migration.options.DatabaseOperationOption;
 
 public final class VersionOperation extends DatabaseOperation<VersionOperation> {
-  private BigDecimal version;
+  private Long version;
 
-  public VersionOperation(BigDecimal version) {
+  public VersionOperation(Long version) {
     super();
     this.version = version;
     if (version == null) {

--- a/src/main/java/org/apache/ibatis/migration/options/DatabaseOperationOption.java
+++ b/src/main/java/org/apache/ibatis/migration/options/DatabaseOperationOption.java
@@ -17,10 +17,18 @@ package org.apache.ibatis.migration.options;
 
 public class DatabaseOperationOption {
   private static final String DEFAULT_CHANGELOG_TABLE = "CHANGELOG";
+  
+  private static final String DEFAULT_CHANGELOG_INSERT = "INSERT INTO ${changelog} (ID, APPLIED_AT, DESCRIPTION) VALUES (?,?,?)";
+
+  private static final String DEFAULT_CHANGELOG_DELETE = "DELETE FROM ${changelog} WHERE ID = ?";
 
   private static final String DEFAULT_DELIMITER = ";";
 
   private String changelogTable;
+  
+  private String changelogInsert;
+  
+  private String changelogDelete;
 
   private boolean stopOnError = true;
 
@@ -42,6 +50,22 @@ public class DatabaseOperationOption {
 
   public void setChangelogTable(String changelogTable) {
     this.changelogTable = changelogTable;
+  }
+  
+  public String getChangelogInsert() {
+	  return changelogInsert == null ? DEFAULT_CHANGELOG_INSERT : changelogInsert;
+  }
+  
+  public void setChangelogInsert(String changelogInsert) {
+	  this.changelogInsert = changelogInsert;
+  }
+  
+  public String getChangelogDelete() {
+	  return changelogDelete == null ? DEFAULT_CHANGELOG_DELETE : changelogDelete;
+  }
+  
+  public void setChangelogDelete(String changelogDelete) {
+	  this.changelogDelete = changelogDelete;
   }
 
   public boolean isStopOnError() {

--- a/src/test/java/org/apache/ibatis/migration/example/environments/nosql.properties
+++ b/src/test/java/org/apache/ibatis/migration/example/environments/nosql.properties
@@ -5,17 +5,18 @@ time_zone=GMT+0:00
 # script_char_set=UTF-8
 
 ## JDBC connection properties.
-driver=
-url=
+driver=org.apache.derby.jdbc.EmbeddedDriver
+url=jdbc:derby:ibderby;create=true
 username=
 password=
 
 #
 # A NOTE ON STORED PROCEDURES AND DELIMITERS
 #
-# Stored procedures and functions commonly have nested delimiters
-# that conflict with the schema migration parsing.  If you tend
-# to use procs, functions, triggers or anything that could create
+# Stored procedures and
+# functions commonly have nested delimiters that conflict
+# with the schema migration parsing.  If you tend to use
+# procs, functions, triggers or anything that could create
 # this situation, then you may want to experiment with
 # send_full_script=true (preferred), or if you can't use
 # send_full_script, then you may have to resort to a full
@@ -30,7 +31,7 @@ password=
 # simply sends the entire script at once.
 # Use with JDBC drivers that can accept large
 # blocks of delimited text at once.
-send_full_script=true
+send_full_script=false
 
 # This controls how statements are delimited.
 # By default statements are delimited by an
@@ -58,8 +59,8 @@ changelog=CHANGELOG
 # By default the changelog table is updated with standard insert and delete statements.
 # Some databases may not support these, so you can specify custom statements for logging changes.
 # Example: The following statements work for Hive databases
-# changelog_insert=INSERT INTO ${changelog} VALUES (?,?,?)
-# changelog_delete=INSERT OVERWRITE TABLE ${changelog} SELECT ID, APPLIED_AT, DESCRIPTION FROM ${changelog} WHERE ID <> ?
+changelog_insert=INSERT INTO ${changelog} VALUES (?,?,?)
+changelog_delete=INSERT OVERWRITE TABLE ${changelog} SELECT ID, APPLIED_AT, DESCRIPTION FROM ${changelog} WHERE ID <> ?
 
 # Migrations support variable substitutions in the form of ${variable}
 # in the migration scripts.  All of the above properties will be ignored though,

--- a/src/test/java/org/apache/ibatis/migration/runtime_migration/RuntimeMigrationTest.java
+++ b/src/test/java/org/apache/ibatis/migration/runtime_migration/RuntimeMigrationTest.java
@@ -15,12 +15,12 @@
  */
 package org.apache.ibatis.migration.runtime_migration;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
-import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -146,7 +146,7 @@ public class RuntimeMigrationTest {
     // Need changelog.
     new UpOperation(1).operate(connectionProvider, migrationsLoader, dbOption, new PrintStream(out));
 
-    new VersionOperation(new BigDecimal("20130707120738")).operate(connectionProvider, migrationsLoader, dbOption, new PrintStream(out));
+    new VersionOperation(Long.valueOf("20130707120738")).operate(connectionProvider, migrationsLoader, dbOption, new PrintStream(out));
     assertEquals("2", runQuery(connectionProvider, "select count(*) from changelog"));
     assertEquals("0", runQuery(connectionProvider, "select count(*) from first_table"));
     assertTableDoesNotExist(connectionProvider, "second_table");
@@ -156,7 +156,7 @@ public class RuntimeMigrationTest {
   public void testVersionDown() throws Exception {
     new UpOperation().operate(connectionProvider, migrationsLoader, dbOption, new PrintStream(out));
 
-    new VersionOperation(new BigDecimal("20130707120738")).operate(connectionProvider, migrationsLoader, dbOption, new PrintStream(out));
+    new VersionOperation(Long.valueOf("20130707120738")).operate(connectionProvider, migrationsLoader, dbOption, new PrintStream(out));
     assertEquals("2", runQuery(connectionProvider, "select count(*) from changelog"));
     assertEquals("0", runQuery(connectionProvider, "select count(*) from first_table"));
     assertTableDoesNotExist(connectionProvider, "second_table");

--- a/src/test/java/org/apache/ibatis/migration/runtime_migration/scripts_java/V001_CreateChangelog.java
+++ b/src/test/java/org/apache/ibatis/migration/runtime_migration/scripts_java/V001_CreateChangelog.java
@@ -15,15 +15,13 @@
  */
 package org.apache.ibatis.migration.runtime_migration.scripts_java;
 
-import java.math.BigDecimal;
-
 import org.apache.ibatis.migration.MigrationScript;
 
 public class V001_CreateChangelog implements MigrationScript {
 
   @Override
-  public BigDecimal getId() {
-    return new BigDecimal(this.getClass().getSimpleName().substring(1, 4));
+  public Long getId() {
+    return Long.valueOf(this.getClass().getSimpleName().substring(1, 4));
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/migration/runtime_migration/scripts_java/V002_CreateFirstTable.java
+++ b/src/test/java/org/apache/ibatis/migration/runtime_migration/scripts_java/V002_CreateFirstTable.java
@@ -15,15 +15,13 @@
  */
 package org.apache.ibatis.migration.runtime_migration.scripts_java;
 
-import java.math.BigDecimal;
-
 import org.apache.ibatis.migration.MigrationScript;
 
 public class V002_CreateFirstTable implements MigrationScript {
 
   @Override
-  public BigDecimal getId() {
-    return new BigDecimal(this.getClass().getSimpleName().substring(1, 4));
+  public Long getId() {
+    return Long.valueOf(this.getClass().getSimpleName().substring(1, 4));
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/migration/runtime_migration/scripts_java/V003_CreateSecondTable.java
+++ b/src/test/java/org/apache/ibatis/migration/runtime_migration/scripts_java/V003_CreateSecondTable.java
@@ -15,15 +15,13 @@
  */
 package org.apache.ibatis.migration.runtime_migration.scripts_java;
 
-import java.math.BigDecimal;
-
 import org.apache.ibatis.migration.MigrationScript;
 
 public class V003_CreateSecondTable implements MigrationScript {
 
   @Override
-  public BigDecimal getId() {
-    return new BigDecimal(this.getClass().getSimpleName().substring(1, 4));
+  public Long getId() {
+    return Long.valueOf(this.getClass().getSimpleName().substring(1, 4));
   }
 
   @Override


### PR DESCRIPTION
I've used MyBatis Migrations with MySQL in the past and was in need of migrating a Hive database.
Unfortunately this didn't work out of the box, so I've made some slight changes that hopefully will find their way into the project.
Here's an overview of what I did:
- updated parent version to 27 to enable building the project with the latest parent
- changed the type of Change.id from BigDecimal to Long because Hive JDBC unfortunately doesn't support setting BigDecimals in Prepared Statements
  - this may be the most controversial modification of this pull request, but I couldn't see why the change id should be stored as a big decimal, which to my knowledge is only useful when working with floating numbers
- added two optional attributes to the environment properties to support less traditional SQL databases:
  - *changelog_insert* can contain a custom statement for inserting a record into the changelog table
  - *changelog_delete*  can contain a custom statement for deleting a record from the changelog table
- updated MigratorTest:
  - made a few test cases independent that don't need to be run in a specific order (like testHelp, testDoScript etc.)
  - added two test cases that generate a script for a newly defined environment (nosql) to test the proper usage of the new properties