### PR TITLE
Use JDBC metadata to check changelog existence

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
@@ -18,6 +18,8 @@ package org.apache.ibatis.migration.operations;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -73,14 +75,17 @@ public abstract class DatabaseOperation<T extends DatabaseOperation<T>> {
   }
 
   protected boolean changelogExists(ConnectionProvider connectionProvider, DatabaseOperationOption option) {
-    SqlRunner runner = getSqlRunner(connectionProvider);
     try {
-      runner.selectAll("select ID, APPLIED_AT, DESCRIPTION from " + option.getChangelogTable());
-      return true;
+      Connection connection = connectionProvider.getConnection();
+      final ResultSet rs = connection.getMetaData().getTables(null, null, null, new String[]{"TABLE"});
+      boolean result = false;
+      while(rs.next()) {
+        result |= rs.getString("table_name").toLowerCase().equals(option.getChangelogTable().toLowerCase());
+      }
+      connection.close();
+      return result;
     } catch (SQLException e) {
-      return false;
-    } finally {
-      runner.closeConnection();
+      throw new MigrationException("Could not check changelog existence. Cause: " +e, e);
     }
   }
 


### PR DESCRIPTION
PostgreSQL default behaviour requires transaction to be rolled back if any error happens, preventing migration. Database metadata allows to check table existence without raising exceptions