### PR TITLE
A new option: ignoreWarnings

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/Environment.java
+++ b/src/main/java/org/apache/ibatis/migration/Environment.java
@@ -32,7 +32,7 @@ public class Environment {
   public static final String CHANGELOG = "changelog";
 
   private enum SETTING_KEY {
-    time_zone, delimiter, script_char_set, full_line_delimiter, send_full_script, auto_commit, remove_crs, driver_path, driver, url, username, password, hook_before_up, hook_before_each_up, hook_after_each_up, hook_after_up, hook_before_down, hook_before_each_down, hook_after_each_down, hook_after_down
+    time_zone, delimiter, script_char_set, full_line_delimiter, send_full_script, auto_commit, remove_crs, ignore_warnings, driver_path, driver, url, username, password, hook_before_up, hook_before_each_up, hook_after_each_up, hook_after_up, hook_before_down, hook_before_each_down, hook_after_each_down, hook_after_down
   }
 
   private static final List<String> SETTING_KEYS;
@@ -53,6 +53,7 @@ public class Environment {
   private final boolean sendFullScript;
   private final boolean autoCommit;
   private final boolean removeCrs;
+  private final boolean ignoreWarnings;
   private final String driverPath;
   private final String driver;
   private final String url;
@@ -84,6 +85,7 @@ public class Environment {
       this.sendFullScript = Boolean.valueOf(prop.getProperty(SETTING_KEY.send_full_script.name()));
       this.autoCommit = Boolean.valueOf(prop.getProperty(SETTING_KEY.auto_commit.name()));
       this.removeCrs = Boolean.valueOf(prop.getProperty(SETTING_KEY.remove_crs.name()));
+      this.ignoreWarnings = Boolean.valueOf(prop.getProperty(SETTING_KEY.ignore_warnings.name()));
 
       this.driverPath = prop.getProperty(SETTING_KEY.driver_path.name());
       this.driver = prop.getProperty(SETTING_KEY.driver.name());
@@ -149,6 +151,10 @@ public class Environment {
 
   public boolean isRemoveCrs() {
     return removeCrs;
+  }
+
+  public boolean isIgnoreWarnings() {
+    return ignoreWarnings;
   }
 
   public String getDriverPath() {

--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -325,7 +325,7 @@ public abstract class BaseCommand implements Command {
     DatabaseOperationOption option = new DatabaseOperationOption();
     option.setChangelogTable(changelogTable());
     option.setStopOnError(!options.isForce());
-    option.setThrowWarning(!options.isForce());
+    option.setThrowWarning(!options.isForce() && !environment().isIgnoreWarnings());
     option.setEscapeProcessing(false);
     option.setAutoCommit(environment().isAutoCommit());
     option.setFullLineDelimiter(environment().isFullLineDelimiter());

--- a/src/main/java/org/apache/ibatis/migration/template_environment.properties
+++ b/src/main/java/org/apache/ibatis/migration/template_environment.properties
@@ -1,5 +1,5 @@
 #
-#    Copyright 2010-2016 the original author or authors.
+#    Copyright 2010-2017 the original author or authors.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -63,6 +63,9 @@ full_line_delimiter=false
 # Few databases should need this set to true,
 # but some do.
 auto_commit=false
+
+# If set to true, warnings from the database do not interrupt migrations.
+ignore_warnings=false
 
 # Custom driver path to allow you to centralize your driver files
 # Default requires the drivers to be in the drivers directory of your

--- a/src/site/xdoc/init.xml
+++ b/src/site/xdoc/init.xml
@@ -91,6 +91,9 @@ full_line_delimiter=false
 # Use with JDBC drivers that can accept large
 # blocks of delimited text at once.
 send_full_script=false
+# If set to true, warnings from the database
+# do not interrupt migrations.
+ignore_warnings=false
 # Custom driver path to avoid copying your drivers
 # driver_path=]]></source>
       </subsection>

--- a/src/site/xdoc/migrate.xml
+++ b/src/site/xdoc/migrate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2010-2016 the original author or authors.
+       Copyright 2010-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
                [--template=<path to template>]
 --path=<directory>   Path to repository.  Default current working directory.
 --env=<environment>  Environment to configure. Default environment is 'development'.
---force              Forces script to continue even if SQL errors are encountered.
+--force              Forces script to continue even if SQL errors or warnings are encountered.
 --help               Displays this usage message.
 --trace              Shows additional error details (if any).
 --template           (Optional) Specify template to be used with ‘new'command


### PR DESCRIPTION
If set to true, a warning raised by the database is ignored and migration continues.
This should fix #84 .