### PR TITLE
Reduce memory usage when reading a large script file.

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/MigrationReader.java
+++ b/src/main/java/org/apache/ibatis/migration/MigrationReader.java
@@ -15,25 +15,64 @@
  */
 package org.apache.ibatis.migration;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FilterReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.util.Properties;
 
 import org.apache.ibatis.parsing.PropertyParser;
 
-public class MigrationReader extends Reader {
+public class MigrationReader extends FilterReader {
 
-  private static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
+  private final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
 
-  private Reader target;
+  private static final String UNDO_TAG = "@UNDO";
+
+  private boolean undo;
+
+  private Properties variables;
+
+  private Part part = Part.NEW_LINE;
+
+  private VariableStatus variableStatus = VariableStatus.NOTHING;
+
+  private char previousChar;
+
+  private int undoIndex = 0;
+
+  private int afterCommentPrefixIndex;
+
+  private int afterDoubleSlashIndex;
+
+  private boolean inUndo;
+
+  private final StringBuilder buffer = new StringBuilder();
+
+  private final StringBuilder lineBuffer = new StringBuilder();
+
+  private enum Part {
+    NOT_UNDO_LINE,
+    NEW_LINE,
+    COMMENT_PREFIX,
+    AFTER_COMMENT_PREFIX,
+    DOUBLE_SLASH,
+    AFTER_DOUBLE_SLASH,
+    UNDO_TAG,
+    AFTER_UNDO_TAG
+  }
+
+  private enum VariableStatus {
+    NOTHING,
+    FOUND_DOLLAR,
+    FOUND_OPEN_BRACE,
+    FOUND_POSSIBLE_VARIABLE
+  }
 
   public MigrationReader(File file, String charset, boolean undo, Properties variables) throws IOException {
     this(new FileInputStream(file), charset, undo, variables);
@@ -41,44 +80,191 @@ public class MigrationReader extends Reader {
 
   public MigrationReader(InputStream inputStream, String charset, boolean undo, Properties variables)
       throws IOException {
-    final Reader source = scriptFileReader(inputStream, charset);
-    try {
-      BufferedReader reader = new BufferedReader(source);
-      StringBuilder doBuilder = new StringBuilder();
-      StringBuilder undoBuilder = new StringBuilder();
-      StringBuilder currentBuilder = doBuilder;
-      String line;
-      while ((line = reader.readLine()) != null) {
-        if (line.trim().matches("^--\\s*//.*$")) {
-          if (line.contains("@UNDO")) {
-            currentBuilder = undoBuilder;
-          }
-          line = line.replaceFirst("--\\s*//", "-- ");
-        }
-        currentBuilder.append(line);
-        currentBuilder.append(LINE_SEPARATOR);
-      }
-      if (undo) {
-        target = new StringReader(PropertyParser.parse(undoBuilder.toString(), variables));
-      } else {
-        target = new StringReader(PropertyParser.parse(doBuilder.toString(), variables));
-      }
-    } finally {
-      source.close();
-    }
+    super(scriptFileReader(inputStream, charset));
+    this.undo = undo;
+    this.variables = variables;
   }
 
   @Override
   public int read(char[] cbuf, int off, int len) throws IOException {
-    return target.read(cbuf, off, len);
+    if (!undo && inUndo) {
+      if (buffer.length() > 0) {
+        return readFromBuffer(cbuf, off, len);
+      }
+      return -1;
+    }
+    while (buffer.length() == 0) {
+      int result = in.read(cbuf, off, len);
+      if (result == -1) {
+        if (lineBuffer.length() > 0 && !undo && !inUndo) {
+          buffer.append(lineBuffer).append(LINE_SEPARATOR);
+          lineBuffer.setLength(0);
+        }
+        if (buffer.length() > 0) {
+          break;
+        }
+        return -1;
+      }
+
+      for (int i = off; i < off + result; i++) {
+        char c = cbuf[i];
+
+        determinePart(c);
+        searchVariable(c);
+
+        if (c == '\r' || (c == '\n' && previousChar != '\r')) {
+          switch (part) {
+            case AFTER_UNDO_TAG:
+              if (undo) {
+                replaceVariables();
+                buffer.append(lineBuffer.delete(afterCommentPrefixIndex, afterDoubleSlashIndex)
+                    .insert(afterCommentPrefixIndex, ' ')).append(LINE_SEPARATOR);
+                lineBuffer.setLength(0);
+                inUndo = true;
+              } else {
+                // Won't read from the file anymore.
+                lineBuffer.setLength(0);
+                int bufferLen = buffer.length();
+                if (bufferLen == 0) {
+                  return -1;
+                } else {
+                  return readFromBuffer(cbuf, off, bufferLen);
+                }
+              }
+              break;
+            case NOT_UNDO_LINE:
+              if (!undo || (undo && inUndo)) {
+                replaceVariables();
+                buffer.append(lineBuffer).append(LINE_SEPARATOR);
+              }
+              lineBuffer.setLength(0);
+              break;
+            default:
+              break;
+          }
+          part = Part.NEW_LINE;
+        } else if (c == '\n') {
+          // LF after CR
+          part = Part.NEW_LINE;
+        } else {
+          lineBuffer.append(c);
+        }
+        previousChar = c;
+      }
+    }
+    return readFromBuffer(cbuf, off, len);
+  }
+
+  private void replaceVariables() {
+    if (variableStatus == VariableStatus.FOUND_POSSIBLE_VARIABLE) {
+      String lineBufferStr = lineBuffer.toString();
+      String processed = PropertyParser.parse(lineBufferStr, variables);
+      if (!lineBufferStr.equals(processed)) {
+        lineBuffer.setLength(0);
+        lineBuffer.append(processed);
+      }
+    }
+    variableStatus = VariableStatus.NOTHING;
+  }
+
+  private int readFromBuffer(char[] cbuf, int off, int len) {
+    int bufferLen = buffer.length();
+    int read = bufferLen > len ? len : bufferLen;
+    buffer.getChars(0, read, cbuf, off);
+    buffer.delete(0, read);
+    return read;
+  }
+
+  private void determinePart(char c) {
+    switch (part) {
+      case NEW_LINE:
+        if (inUndo) {
+          part = Part.NOT_UNDO_LINE;
+        } else if (c == 0x09 || c == 0x20) {
+          // ignore whitespace
+        } else if (c == '/' || c == '-') {
+          part = Part.COMMENT_PREFIX;
+        } else {
+          part = Part.NOT_UNDO_LINE;
+        }
+        break;
+      case COMMENT_PREFIX:
+        if ((c == '/' || c == '-') && c == previousChar) {
+          part = Part.AFTER_COMMENT_PREFIX;
+          afterCommentPrefixIndex = lineBuffer.length() + 1;
+        } else {
+          part = Part.NOT_UNDO_LINE;
+        }
+        break;
+      case AFTER_COMMENT_PREFIX:
+        if (c == 0x09 || c == 0x20) {
+          // ignore whitespace
+        } else if (c == '/') {
+          part = Part.DOUBLE_SLASH;
+        } else {
+          part = Part.NOT_UNDO_LINE;
+        }
+        break;
+      case DOUBLE_SLASH:
+        if (c == '/' && c == previousChar) {
+          part = Part.AFTER_DOUBLE_SLASH;
+          afterDoubleSlashIndex = lineBuffer.length() + 1;
+          undoIndex = 0;
+        } else {
+          part = Part.NOT_UNDO_LINE;
+        }
+        break;
+      case AFTER_DOUBLE_SLASH:
+        if (c == 0x09 || c == 0x20) {
+          // ignore whitespace
+        } else if (c == UNDO_TAG.charAt(undoIndex)) {
+          part = Part.UNDO_TAG;
+          undoIndex = 1;
+        } else {
+          part = Part.NOT_UNDO_LINE;
+        }
+        break;
+      case UNDO_TAG:
+        if (c == UNDO_TAG.charAt(undoIndex)) {
+          if (++undoIndex >= UNDO_TAG.length()) {
+            part = Part.AFTER_UNDO_TAG;
+          }
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  private void searchVariable(char c) {
+    // This is just a quick check.
+    switch (variableStatus) {
+      case NOTHING:
+        if ((part == Part.NOT_UNDO_LINE || part == Part.AFTER_UNDO_TAG) && c == '$') {
+          variableStatus = VariableStatus.FOUND_DOLLAR;
+        }
+        break;
+      case FOUND_DOLLAR:
+        variableStatus = c == '{' ? VariableStatus.FOUND_OPEN_BRACE : VariableStatus.NOTHING;
+        break;
+      case FOUND_OPEN_BRACE:
+        if (c == '}') {
+          variableStatus = VariableStatus.FOUND_POSSIBLE_VARIABLE;
+        }
+        break;
+      default:
+        break;
+    }
   }
 
   @Override
-  public void close() throws IOException {
-    target.close();
+  public int read() throws IOException {
+    char[] buf = new char[1];
+    int result = read(buf, 0, 1);
+    return result == -1 ? -1 : (int) buf[0];
   }
 
-  protected Reader scriptFileReader(InputStream inputStream, String charset)
+  protected static Reader scriptFileReader(InputStream inputStream, String charset)
       throws FileNotFoundException, UnsupportedEncodingException {
     if (charset == null || charset.length() == 0) {
       return new InputStreamReader(inputStream);

--- a/src/test/java/org/apache/ibatis/migration/MigrationReaderTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigrationReaderTest.java
@@ -48,6 +48,7 @@ public class MigrationReaderTest {
 
   @Test
   public void shouldReturnDoPart() throws Exception {
+    // @formatter:off
     String script = "-- comment\n"
         + "do part\n"
         + "--//@UNDO\n"
@@ -55,10 +56,12 @@ public class MigrationReaderTest {
     String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
     assertEquals("-- comment\n"
         + "do part\n", result);
+    // @formatter:on
   }
 
   @Test
   public void shouldReturnUndoPart() throws Exception {
+    // @formatter:off
     String script = "-- comment\n"
         + "do part\n"
         + "--//@UNDO\n"
@@ -66,10 +69,12 @@ public class MigrationReaderTest {
     String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
     assertEquals("-- @UNDO\n"
         + "undo part\n", result);
+    // @formatter:on
   }
 
   @Test
   public void shouldUndoCommentBeLenient() throws Exception {
+    // @formatter:off
     String script = "-- comment\n"
         + "do part\n"
         + " \t --  \t //  \t@UNDO  a \n"
@@ -77,11 +82,13 @@ public class MigrationReaderTest {
     String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
     assertEquals(" \t --   \t@UNDO  a \n"
         + "undo part\n", result);
+    // @formatter:on
   }
 
   @Ignore("This won't work since 3.2.2 for performance reason.")
   @Test
   public void shouldUndoCommentAllowAnyCharBeforeAtMark() throws Exception {
+    // @formatter:off
     String script = "-- comment\n"
         + "do part\n"
         + "-- // b @UNDO\n"
@@ -89,25 +96,30 @@ public class MigrationReaderTest {
     String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
     assertEquals("--  b @UNDO\n"
         + "undo part\n", result);
+    // @formatter:on
   }
 
   @Test
   public void shouldRequireDoubleSlashInUndoComment() throws Exception {
+    // @formatter:off
     String script = "-- comment\n"
         + "do part\n"
         + "-- @UNDO\n"
         + "undo part\n";
+    // @formatter:on
     String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
     assertEquals("", result);
   }
 
   @Test
   public void shouldReturnAllAsDoIfUndoCommentNotFound() throws Exception {
+    // @formatter:off
     String script = "-- comment\n"
         + "do part\n";
     String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
     assertEquals("-- comment\n"
         + "do part\n", result);
+    // @formatter:on
   }
 
   @Test
@@ -119,8 +131,10 @@ public class MigrationReaderTest {
 
   @Test
   public void shouldReturnEmptyUndoIfUndoCommentNotFound() throws Exception {
+    // @formatter:off
     String script = "-- comment\n"
         + "do part\n";
+    // @formatter:on
     String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
     assertEquals("", result);
   }
@@ -135,6 +149,7 @@ public class MigrationReaderTest {
   @Ignore("This won't work since 3.2.2 mainly for performance reason.")
   @Test
   public void shouldRemoveFirstDoubleSlashInEveryComment_Do() throws Exception {
+    // @formatter:off
     String script = "--  //  comment\n"
         + "do part\n"
         + "--//@UNDO\n"
@@ -143,11 +158,13 @@ public class MigrationReaderTest {
     String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
     assertEquals("--   comment\n"
         + "do part\n", result);
+    // @formatter:on
   }
 
   @Ignore("This won't work since 3.2.2 mainly for performance reason.")
   @Test
   public void shouldRemoveFirstDoubleSlashInEveryComment_Undo() throws Exception {
+    // @formatter:off
     String script = "--  //  comment\n"
         + "do part\n"
         + "--//@UNDO\n"
@@ -157,10 +174,12 @@ public class MigrationReaderTest {
     assertEquals("-- @UNDO\n"
         + "-- some comment\n"
         + "undo part\n", result);
+    // @formatter:on
   }
 
   @Test
   public void shouldSecondUndoMarkerHaveNoEffect() throws Exception {
+    // @formatter:off
     String script = "--  //  comment\n"
         + "do part\n"
         + "--//@UNDO\n"
@@ -172,10 +191,12 @@ public class MigrationReaderTest {
         + "first undo part\n"
         + "--//@UNDO\n"
         + "second undo part\n", result);
+    // @formatter:on
   }
 
   @Test
   public void shouldReplaceVariables_Do() throws Exception {
+    // @formatter:off
     String script = "do ${a} part${b} \n"
         + "-- ${a}\n"
         + "${c} \\${b}\n"
@@ -189,10 +210,12 @@ public class MigrationReaderTest {
     assertEquals("do AAA partBBB \n"
         + "-- AAA\n"
         + "CCC ${b}\n", result);
+    // @formatter:on
   }
 
   @Test
   public void shouldReplaceVariables_Undo() throws Exception {
+    // @formatter:off
     String script = "do part\n"
         + "--//@UNDO ${c}\n"
         + "undo ${a} part${b} \n"
@@ -207,6 +230,7 @@ public class MigrationReaderTest {
         + "undo AAA partBBB \n"
         + "-- AAA\n"
         + "CCC ${b}\n", result);
+    // @formatter:on
   }
 
   @Test
@@ -216,6 +240,7 @@ public class MigrationReaderTest {
     String originalSeparator = System.getProperty("line.separator");
     System.setProperty("line.separator", "\r\n");
     try {
+      // @formatter:off
       String script = "do part 1\n"
           + "do part 2\n"
           + "--//@UNDO ${c}\n"
@@ -224,6 +249,7 @@ public class MigrationReaderTest {
       String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
       assertEquals("do part 1\r\n"
           + "do part 2\r\n", result);
+      // @formatter:on
     } finally {
       System.setProperty("line.separator", originalSeparator);
     }
@@ -236,6 +262,7 @@ public class MigrationReaderTest {
     String originalSeparator = System.getProperty("line.separator");
     try {
       System.setProperty("line.separator", "\r");
+      // @formatter:off
       String script = "do part 1\r\n"
           + "do part 2\r\n"
           + "--//@UNDO\r\n"
@@ -245,6 +272,7 @@ public class MigrationReaderTest {
       assertEquals("-- @UNDO\r"
           + "undo part 1\r"
           + "undo part 2\r", result);
+      // @formatter:on
     } finally {
       System.setProperty("line.separator", originalSeparator);
     }

--- a/src/test/java/org/apache/ibatis/migration/MigrationReaderTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigrationReaderTest.java
@@ -1,0 +1,283 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.migration;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class MigrationReaderTest {
+  private static final String charset = "utf-8";
+
+  private String lineSeparator;
+
+  @Before
+  public void beforeEachTest() {
+    lineSeparator = System.getProperty("line.separator");
+    System.setProperty("line.separator", "\n");
+
+  }
+
+  @After
+  public void afterEachTest() {
+    System.setProperty("line.separator", lineSeparator);
+  }
+
+  @Test
+  public void shouldReturnDoPart() throws Exception {
+    String script = "-- comment\n"
+        + "do part\n"
+        + "--//@UNDO\n"
+        + "undo part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
+    assertEquals("-- comment\n"
+        + "do part\n", result);
+  }
+
+  @Test
+  public void shouldReturnUndoPart() throws Exception {
+    String script = "-- comment\n"
+        + "do part\n"
+        + "--//@UNDO\n"
+        + "undo part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+    assertEquals("-- @UNDO\n"
+        + "undo part\n", result);
+  }
+
+  @Test
+  public void shouldUndoCommentBeLenient() throws Exception {
+    String script = "-- comment\n"
+        + "do part\n"
+        + " \t --  \t //  \t@UNDO  a \n"
+        + "undo part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+    assertEquals(" \t --   \t@UNDO  a \n"
+        + "undo part\n", result);
+  }
+
+  @Ignore("This won't work since 3.2.2 for performance reason.")
+  @Test
+  public void shouldUndoCommentAllowAnyCharBeforeAtMark() throws Exception {
+    String script = "-- comment\n"
+        + "do part\n"
+        + "-- // b @UNDO\n"
+        + "undo part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+    assertEquals("--  b @UNDO\n"
+        + "undo part\n", result);
+  }
+
+  @Test
+  public void shouldRequireDoubleSlashInUndoComment() throws Exception {
+    String script = "-- comment\n"
+        + "do part\n"
+        + "-- @UNDO\n"
+        + "undo part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+    assertEquals("", result);
+  }
+
+  @Test
+  public void shouldReturnAllAsDoIfUndoCommentNotFound() throws Exception {
+    String script = "-- comment\n"
+        + "do part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
+    assertEquals("-- comment\n"
+        + "do part\n", result);
+  }
+
+  @Test
+  public void shouldReturnAllAsDoIfUndoCommentNotFound_NoEndBreak() throws Exception {
+    String script = "-- ";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
+    assertEquals("-- \n", result);
+  }
+
+  @Test
+  public void shouldReturnEmptyUndoIfUndoCommentNotFound() throws Exception {
+    String script = "-- comment\n"
+        + "do part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+    assertEquals("", result);
+  }
+
+  @Test
+  public void shouldReturnEmptyUndoIfUndoCommentNotFound_NoEndBreak() throws Exception {
+    String script = "-- ";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+    assertEquals("", result);
+  }
+
+  @Ignore("This won't work since 3.2.2 mainly for performance reason.")
+  @Test
+  public void shouldRemoveFirstDoubleSlashInEveryComment_Do() throws Exception {
+    String script = "--  //  comment\n"
+        + "do part\n"
+        + "--//@UNDO\n"
+        + "--//some comment\n"
+        + "undo part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
+    assertEquals("--   comment\n"
+        + "do part\n", result);
+  }
+
+  @Ignore("This won't work since 3.2.2 mainly for performance reason.")
+  @Test
+  public void shouldRemoveFirstDoubleSlashInEveryComment_Undo() throws Exception {
+    String script = "--  //  comment\n"
+        + "do part\n"
+        + "--//@UNDO\n"
+        + "--//some comment\n"
+        + "undo part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+    assertEquals("-- @UNDO\n"
+        + "-- some comment\n"
+        + "undo part\n", result);
+  }
+
+  @Test
+  public void shouldSecondUndoMarkerHaveNoEffect() throws Exception {
+    String script = "--  //  comment\n"
+        + "do part\n"
+        + "--//@UNDO\n"
+        + "first undo part\n"
+        + "--//@UNDO\n"
+        + "second undo part\n";
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+    assertEquals("-- @UNDO\n"
+        + "first undo part\n"
+        + "--//@UNDO\n"
+        + "second undo part\n", result);
+  }
+
+  @Test
+  public void shouldReplaceVariables_Do() throws Exception {
+    String script = "do ${a} part${b} \n"
+        + "-- ${a}\n"
+        + "${c} \\${b}\n"
+        + "--//@UNDO\n"
+        + "undo part\n";
+    Properties vars = new Properties();
+    vars.put("a", "AAA");
+    vars.put("b", "BBB");
+    vars.put("c", "CCC");
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, vars));
+    assertEquals("do AAA partBBB \n"
+        + "-- AAA\n"
+        + "CCC ${b}\n", result);
+  }
+
+  @Test
+  public void shouldReplaceVariables_Undo() throws Exception {
+    String script = "do part\n"
+        + "--//@UNDO ${c}\n"
+        + "undo ${a} part${b} \n"
+        + "-- ${a}\n"
+        + "${c} \\${b}\n";
+    Properties vars = new Properties();
+    vars.put("a", "AAA");
+    vars.put("b", "BBB");
+    vars.put("c", "CCC");
+    String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, vars));
+    assertEquals("-- @UNDO CCC\n"
+        + "undo AAA partBBB \n"
+        + "-- AAA\n"
+        + "CCC ${b}\n", result);
+  }
+
+  @Test
+  public void shouldNormalizeLineSeparator_Do() throws Exception {
+    // This is just for consistency with older versions.
+    // ScriptRunner normalizes line separator anyway.
+    String originalSeparator = System.getProperty("line.separator");
+    System.setProperty("line.separator", "\r\n");
+    try {
+      String script = "do part 1\n"
+          + "do part 2\n"
+          + "--//@UNDO ${c}\n"
+          + "undo part 1\n"
+          + "undo part 2\n";
+      String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, false, null));
+      assertEquals("do part 1\r\n"
+          + "do part 2\r\n", result);
+    } finally {
+      System.setProperty("line.separator", originalSeparator);
+    }
+  }
+
+  @Test
+  public void shouldNormalizeLineSeparator_Undo() throws Exception {
+    // This is just for consistency with older versions.
+    // ScriptRunner normalizes line separator anyway.
+    String originalSeparator = System.getProperty("line.separator");
+    try {
+      System.setProperty("line.separator", "\r");
+      String script = "do part 1\r\n"
+          + "do part 2\r\n"
+          + "--//@UNDO\r\n"
+          + "undo part 1\r\n"
+          + "undo part 2\r\n";
+      String result = readAsString(new MigrationReader(strToInputStream(script, charset), charset, true, null));
+      assertEquals("-- @UNDO\r"
+          + "undo part 1\r"
+          + "undo part 2\r", result);
+    } finally {
+      System.setProperty("line.separator", originalSeparator);
+    }
+  }
+
+  @Test
+  public void shouldRespectSpecifiedOffsetAndLength() throws Exception {
+    String script = "abcdefghij";
+    MigrationReader reader = new MigrationReader(strToInputStream(script, charset), charset, false, null);
+    try {
+      char[] cbuf = new char[5];
+      int read = reader.read(cbuf, 1, 3);
+      assertEquals(read, 3);
+      assertArrayEquals(new char[] { 0, 'a', 'b', 'c', 0 }, cbuf);
+    } finally {
+      reader.close();
+    }
+  }
+
+  private String readAsString(Reader reader) throws IOException {
+    try {
+      StringBuilder buffer = new StringBuilder();
+      int res;
+      while ((res = reader.read()) != -1) {
+        buffer.append((char) res);
+      }
+      return buffer.toString();
+    } finally {
+      reader.close();
+    }
+  }
+
+  private InputStream strToInputStream(String str, String charsetName) throws UnsupportedEncodingException {
+    return new ByteArrayInputStream(str.getBytes(charsetName));
+  }
+}

--- a/src/test/java/org/apache/ibatis/migration/MigratorTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigratorTest.java
@@ -97,7 +97,7 @@ public class MigratorTest {
     Migrator.main(TestUtil.args("--path=" + dir.getAbsolutePath(), "bootstrap", "--env=development"));
     String output = out.getLog();
     assertFalse(output.toString().contains("FAILURE"));
-    assertTrue(output.toString().contains("--  Bootstrap.sql"));
+    assertTrue(output.toString().contains("-- // Bootstrap.sql"));
   }
 
   private void testStatusContainsNoPendingEntriesUsingStatusShorthand() throws Exception {


### PR DESCRIPTION
Instead of reading the entire file into String, this version reads a file line by line.

This patch slightly changes the behavior for simplicity.

1. Version ≤ 3.3.1 allowed any character before `@UNDO`. 3.3.2 will allow only spaces and tabs. For example, the following undo marker was valid in ≤3.3.1, but will be invalid in 3.3.2.

   ```
   -- // some comment @UNDO
   ```
1. Version ≤3.3.1 removes the first double slash in any comment line. 3.3.2 will do that only in the `@UNDO` line.

   ```
   -- // some comment (original)
   -- some comment (≤3.3.1)
   -- // some comment (3.3.2)
   ```


Hi @h3adache , 
Is there any reason these changes could cause some problem?