### PR TITLE
Allow subdirectories in scripts directory

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/Change.java
+++ b/src/main/java/org/apache/ibatis/migration/Change.java
@@ -23,6 +23,7 @@ public class Change implements Comparable<Change>, Cloneable {
   private String description;
   private String appliedTimestamp;
   private String filename;
+  private String path = "";
 
   public Change() {
   }
@@ -67,6 +68,18 @@ public class Change implements Comparable<Change>, Cloneable {
 
   public void setFilename(String filename) {
     this.filename = filename;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getFullName() {
+    return getPath() + getFilename();
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/migration/commands/ScriptCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/ScriptCommand.java
@@ -78,7 +78,7 @@ public final class ScriptCommand extends BaseCommand {
       }
       for (Change change : migrations) {
         if (shouldRun(change, v1, v2, scriptPending || scriptPendingUndo)) {
-          printStream.println("-- " + change.getFilename());
+          printStream.println("-- " + change.getFullName());
           Reader migrationReader = getMigrationLoader().getScriptReader(change, undo);
           char[] cbuf = new char[1024];
           int l;

--- a/src/main/java/org/apache/ibatis/migration/operations/DownOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DownOperation.java
@@ -80,7 +80,7 @@ public final class DownOperation extends DatabaseOperation {
                     new HookContext(connectionProvider, runner, change.clone()));
                 hook.beforeEach(hookBindings);
               }
-              println(printStream, Util.horizontalLine("Undoing: " + change.getFilename(), 80));
+              println(printStream, Util.horizontalLine("Undoing: " + change.getFullName(), 80));
               runner.runScript(migrationsLoader.getScriptReader(change, true));
               if (changelogExists(connectionProvider, option)) {
                 deleteChange(connectionProvider, change, option);

--- a/src/main/java/org/apache/ibatis/migration/operations/PendingOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/PendingOperation.java
@@ -65,7 +65,7 @@ public final class PendingOperation extends DatabaseOperation {
             hookBindings.put(MigrationHook.HOOK_CONTEXT, new HookContext(connectionProvider, runner, change.clone()));
             hook.beforeEach(hookBindings);
           }
-          println(printStream, Util.horizontalLine("Applying: " + change.getFilename(), 80));
+          println(printStream, Util.horizontalLine("Applying: " + change.getFullName(), 80));
           scriptReader = migrationsLoader.getScriptReader(change, false);
           runner.runScript(scriptReader);
           insertChangelog(change, connectionProvider, option);

--- a/src/main/java/org/apache/ibatis/migration/operations/UpOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/UpOperation.java
@@ -86,7 +86,7 @@ public final class UpOperation extends DatabaseOperation {
               hookBindings.put(MigrationHook.HOOK_CONTEXT, new HookContext(connectionProvider, runner, change.clone()));
               hook.beforeEach(hookBindings);
             }
-            println(printStream, Util.horizontalLine("Applying: " + change.getFilename(), 80));
+            println(printStream, Util.horizontalLine("Applying: " + change.getFullName(), 80));
             scriptReader = migrationsLoader.getScriptReader(change, false);
             runner.runScript(scriptReader);
             insertChangelog(change, connectionProvider, option);

--- a/src/test/java/org/apache/ibatis/migration/MigratorTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigratorTest.java
@@ -153,7 +153,7 @@ public class MigratorTest {
 
   private void testVersionCommand() throws Exception {
     out.clearLog();
-    Migrator.main(TestUtil.args("--path=" + dir.getAbsolutePath(), "version", "20080827200216"));
+    Migrator.main(TestUtil.args("--path=" + dir.getAbsolutePath(), "version", "20090827200210"));
     String output = out.getLog();
     assertFalse(output.toString().contains("FAILURE"));
   }
@@ -207,6 +207,20 @@ public class MigratorTest {
     assertTrue(output.toString().contains("20080827200213"));
     assertTrue(output.toString().contains("20080827200214"));
     assertFalse(output.toString().contains("20080827200215"));
+    assertFalse(output.toString().contains("20090827200210"));
+    assertFalse(output.toString().contains("-- @UNDO"));
+
+    out.clearLog();
+    Migrator.main(TestUtil.args("--path=" + dir.getAbsolutePath(), "script", "20080827200212", "20090827200210"));
+    output = out.getLog();
+    assertFalse(output.toString().contains("FAILURE"));
+    assertFalse(output.toString().contains("20080827200210"));
+    assertFalse(output.toString().contains("20080827200211"));
+    assertFalse(output.toString().contains("20080827200212"));
+    assertTrue(output.toString().contains("20080827200213"));
+    assertTrue(output.toString().contains("20080827200214"));
+    assertTrue(output.toString().contains("20080827200215"));
+    assertTrue(output.toString().contains("20090827200210"));
     assertFalse(output.toString().contains("-- @UNDO"));
 
     out.clearLog();

--- a/src/test/java/org/apache/ibatis/migration/example/scripts/2009/20090827200210_parse_file_placed_in_subdirectory.sql
+++ b/src/test/java/org/apache/ibatis/migration/example/scripts/2009/20090827200210_parse_file_placed_in_subdirectory.sql
@@ -1,0 +1,23 @@
+--
+--    Copyright 2010-2017 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+-- // First migration.
+-- Migration SQL that makes the change goes here.
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
Hi,

it would be nice to be able to place scripts in subdirectories and grouping them however we like. In our current project we have around 700 scripts and counting. I really dislike navigating through this directory in my IDE.
I let myself to provide an implementation of this feature and I've prepared a pull request.
What do you think of such feature? Is there any reason this change shouldn't be provided?

Regards,
Dawid