### PR TITLE
Colorize output

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/CommandLine.java
+++ b/src/main/java/org/apache/ibatis/migration/CommandLine.java
@@ -26,7 +26,7 @@ import org.apache.ibatis.migration.commands.Command;
 import org.apache.ibatis.migration.options.SelectedOptions;
 import org.apache.ibatis.migration.ConsoleColors;
 
-public class CommandLine implements ConsoleColors {
+public class CommandLine {
   private final PrintStream console = System.out;
   private final String[] args;
 
@@ -46,7 +46,7 @@ public class CommandLine implements ConsoleColors {
       String errorMessage = e.getMessage();
 
       if (selectedOptions.hasColor()) {
-        console.printf(RED + "\nERROR: %s%n", errorMessage + RESET);
+        console.printf(ConsoleColors.RED + "\nERROR: %s%n", errorMessage + ConsoleColors.RESET);
       } else {
         console.printf("\nERROR: %s%n", errorMessage);
       }
@@ -82,8 +82,8 @@ public class CommandLine implements ConsoleColors {
       console.printf("------------------------------------------------------------------------%n");
 
       if (selectedOptions.hasColor()) {
-        console.printf("-- MyBatis Migrations %s%s%s%n", (exceptionCaught) ? RED : GREEN,
-            (exceptionCaught) ? "FAILURE" : "SUCCESS", RESET);
+        console.printf("-- MyBatis Migrations %s%s%s%n", (exceptionCaught) ? ConsoleColors.RED : ConsoleColors.GREEN,
+            (exceptionCaught) ? "FAILURE" : "SUCCESS", ConsoleColors.RESET);
       } else {
         console.printf("-- MyBatis Migrations %s%n", (exceptionCaught) ? "FAILURE" : "SUCCESS");
       }

--- a/src/main/java/org/apache/ibatis/migration/CommandLine.java
+++ b/src/main/java/org/apache/ibatis/migration/CommandLine.java
@@ -24,29 +24,11 @@ import java.util.Date;
 
 import org.apache.ibatis.migration.commands.Command;
 import org.apache.ibatis.migration.options.SelectedOptions;
+import org.apache.ibatis.migration.ConsoleColors;
 
 public class CommandLine {
   private final PrintStream console = System.out;
   private final String[] args;
-
-  public static final String ANSI_RESET = "\u001B[0m";
-  public static final String ANSI_BLACK = "\u001B[30m";
-  public static final String ANSI_RED = "\u001B[31m";
-  public static final String ANSI_GREEN = "\u001B[32m";
-  public static final String ANSI_YELLOW = "\u001B[33m";
-  public static final String ANSI_BLUE = "\u001B[34m";
-  public static final String ANSI_PURPLE = "\u001B[35m";
-  public static final String ANSI_CYAN = "\u001B[36m";
-  public static final String ANSI_WHITE = "\u001B[37m";
-
-  public static final String ANSI_BLACK_BACKGROUND = "\u001B[40m";
-  public static final String ANSI_RED_BACKGROUND = "\u001B[41m";
-  public static final String ANSI_GREEN_BACKGROUND = "\u001B[42m";
-  public static final String ANSI_YELLOW_BACKGROUND = "\u001B[43m";
-  public static final String ANSI_BLUE_BACKGROUND = "\u001B[44m";
-  public static final String ANSI_PURPLE_BACKGROUND = "\u001B[45m";
-  public static final String ANSI_CYAN_BACKGROUND = "\u001B[46m";
-  public static final String ANSI_WHITE_BACKGROUND = "\u001B[47m";
 
   public CommandLine(String[] args) {
     this.args = args;
@@ -64,7 +46,7 @@ public class CommandLine {
       String errorMessage = e.getMessage();
 
       if (selectedOptions.isColor()) {
-        console.printf(ANSI_RED + "\nERROR: %s%n", errorMessage + ANSI_RESET);
+        console.printf(ConsoleColors.RED + "\nERROR: %s%n", errorMessage + ConsoleColors.RESET);
       } else {
         console.printf("\nERROR: %s%n", errorMessage);
       }
@@ -100,8 +82,8 @@ public class CommandLine {
       console.printf("------------------------------------------------------------------------%n");
 
       if (selectedOptions.isColor()) {
-        console.printf("-- MyBatis Migrations %s%s%s%n", (exceptionCaught) ? ANSI_RED : ANSI_GREEN,
-            (exceptionCaught) ? "FAILURE" : "SUCCESS", ANSI_RESET);
+        console.printf("-- MyBatis Migrations %s%s%s%n", (exceptionCaught) ? ConsoleColors.RED : ConsoleColors.GREEN,
+            (exceptionCaught) ? "FAILURE" : "SUCCESS", ConsoleColors.RESET);
       } else {
         console.printf("-- MyBatis Migrations %s%n", (exceptionCaught) ? "FAILURE" : "SUCCESS");
       }

--- a/src/main/java/org/apache/ibatis/migration/CommandLine.java
+++ b/src/main/java/org/apache/ibatis/migration/CommandLine.java
@@ -26,7 +26,7 @@ import org.apache.ibatis.migration.commands.Command;
 import org.apache.ibatis.migration.options.SelectedOptions;
 import org.apache.ibatis.migration.ConsoleColors;
 
-public class CommandLine {
+public class CommandLine implements ConsoleColors {
   private final PrintStream console = System.out;
   private final String[] args;
 
@@ -46,7 +46,7 @@ public class CommandLine {
       String errorMessage = e.getMessage();
 
       if (selectedOptions.hasColor()) {
-        console.printf(ConsoleColors.RED + "\nERROR: %s%n", errorMessage + ConsoleColors.RESET);
+        console.printf(RED + "\nERROR: %s%n", errorMessage + RESET);
       } else {
         console.printf("\nERROR: %s%n", errorMessage);
       }
@@ -82,8 +82,8 @@ public class CommandLine {
       console.printf("------------------------------------------------------------------------%n");
 
       if (selectedOptions.hasColor()) {
-        console.printf("-- MyBatis Migrations %s%s%s%n", (exceptionCaught) ? ConsoleColors.RED : ConsoleColors.GREEN,
-            (exceptionCaught) ? "FAILURE" : "SUCCESS", ConsoleColors.RESET);
+        console.printf("-- MyBatis Migrations %s%s%s%n", (exceptionCaught) ? RED : GREEN,
+            (exceptionCaught) ? "FAILURE" : "SUCCESS", RESET);
       } else {
         console.printf("-- MyBatis Migrations %s%n", (exceptionCaught) ? "FAILURE" : "SUCCESS");
       }

--- a/src/main/java/org/apache/ibatis/migration/CommandLine.java
+++ b/src/main/java/org/apache/ibatis/migration/CommandLine.java
@@ -29,6 +29,25 @@ public class CommandLine {
   private final PrintStream console = System.out;
   private final String[] args;
 
+  public static final String ANSI_RESET = "\u001B[0m";
+  public static final String ANSI_BLACK = "\u001B[30m";
+  public static final String ANSI_RED = "\u001B[31m";
+  public static final String ANSI_GREEN = "\u001B[32m";
+  public static final String ANSI_YELLOW = "\u001B[33m";
+  public static final String ANSI_BLUE = "\u001B[34m";
+  public static final String ANSI_PURPLE = "\u001B[35m";
+  public static final String ANSI_CYAN = "\u001B[36m";
+  public static final String ANSI_WHITE = "\u001B[37m";
+
+  public static final String ANSI_BLACK_BACKGROUND = "\u001B[40m";
+  public static final String ANSI_RED_BACKGROUND = "\u001B[41m";
+  public static final String ANSI_GREEN_BACKGROUND = "\u001B[42m";
+  public static final String ANSI_YELLOW_BACKGROUND = "\u001B[43m";
+  public static final String ANSI_BLUE_BACKGROUND = "\u001B[44m";
+  public static final String ANSI_PURPLE_BACKGROUND = "\u001B[45m";
+  public static final String ANSI_CYAN_BACKGROUND = "\u001B[46m";
+  public static final String ANSI_WHITE_BACKGROUND = "\u001B[47m";
+
   public CommandLine(String[] args) {
     this.args = args;
   }
@@ -42,7 +61,14 @@ public class CommandLine {
         runCommand(selectedOptions);
       }
     } catch (Exception e) {
-      console.printf("\nERROR: %s", e.getMessage());
+      String errorMessage = e.getMessage();
+
+      if (selectedOptions.isColor()) {
+        console.printf(ANSI_RED + "\nERROR: %s%n", errorMessage + ANSI_RESET);
+      } else {
+        console.printf("\nERROR: %s%n", errorMessage);
+      }
+
       if (selectedOptions.isTrace()) {
         e.printStackTrace();
       }
@@ -72,7 +98,14 @@ public class CommandLine {
       }
     } finally {
       console.printf("------------------------------------------------------------------------%n");
-      console.printf("-- MyBatis Migrations %s%n", (exceptionCaught) ? "FAILURE" : "SUCCESS");
+
+      if (selectedOptions.isColor()) {
+        console.printf("-- MyBatis Migrations %s%s%s%n", (exceptionCaught) ? ANSI_RED : ANSI_GREEN,
+            (exceptionCaught) ? "FAILURE" : "SUCCESS", ANSI_RESET);
+      } else {
+        console.printf("-- MyBatis Migrations %s%n", (exceptionCaught) ? "FAILURE" : "SUCCESS");
+      }
+
       console.printf("-- Total time: %ss%n", ((System.currentTimeMillis() - start) / 1000));
       console.printf("-- Finished at: %s%n", new Date());
       printMemoryUsage();
@@ -118,6 +151,7 @@ public class CommandLine {
     console.printf("--help               Displays this usage message.%n");
     console.printf("--trace              Shows additional error details (if any).%n");
     console.printf("--quiet              Suppresses output.%n");
+    console.printf("--color              Colorize output.%n");
     console.printf("%n");
     console.printf("Commands:%n");
     console.printf("  info               Display build version informations.%n");

--- a/src/main/java/org/apache/ibatis/migration/CommandLine.java
+++ b/src/main/java/org/apache/ibatis/migration/CommandLine.java
@@ -45,7 +45,7 @@ public class CommandLine {
     } catch (Exception e) {
       String errorMessage = e.getMessage();
 
-      if (selectedOptions.isColor()) {
+      if (selectedOptions.hasColor()) {
         console.printf(ConsoleColors.RED + "\nERROR: %s%n", errorMessage + ConsoleColors.RESET);
       } else {
         console.printf("\nERROR: %s%n", errorMessage);
@@ -81,7 +81,7 @@ public class CommandLine {
     } finally {
       console.printf("------------------------------------------------------------------------%n");
 
-      if (selectedOptions.isColor()) {
+      if (selectedOptions.hasColor()) {
         console.printf("-- MyBatis Migrations %s%s%s%n", (exceptionCaught) ? ConsoleColors.RED : ConsoleColors.GREEN,
             (exceptionCaught) ? "FAILURE" : "SUCCESS", ConsoleColors.RESET);
       } else {

--- a/src/main/java/org/apache/ibatis/migration/ConsoleColors.java
+++ b/src/main/java/org/apache/ibatis/migration/ConsoleColors.java
@@ -1,0 +1,93 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.migration;
+
+// Credit: https://stackoverflow.com/a/45444716
+
+public class ConsoleColors {
+  // Reset
+  public static final String RESET = "\033[0m";  // Text Reset
+
+  // Regular Colors
+  public static final String BLACK = "\033[0;30m";   // BLACK
+  public static final String RED = "\033[0;31m";     // RED
+  public static final String GREEN = "\033[0;32m";   // GREEN
+  public static final String YELLOW = "\033[0;33m";  // YELLOW
+  public static final String BLUE = "\033[0;34m";    // BLUE
+  public static final String PURPLE = "\033[0;35m";  // PURPLE
+  public static final String CYAN = "\033[0;36m";    // CYAN
+  public static final String WHITE = "\033[0;37m";   // WHITE
+
+  // Bold
+  public static final String BLACK_BOLD = "\033[1;30m";  // BLACK
+  public static final String RED_BOLD = "\033[1;31m";    // RED
+  public static final String GREEN_BOLD = "\033[1;32m";  // GREEN
+  public static final String YELLOW_BOLD = "\033[1;33m"; // YELLOW
+  public static final String BLUE_BOLD = "\033[1;34m";   // BLUE
+  public static final String PURPLE_BOLD = "\033[1;35m"; // PURPLE
+  public static final String CYAN_BOLD = "\033[1;36m";   // CYAN
+  public static final String WHITE_BOLD = "\033[1;37m";  // WHITE
+
+  // Underline
+  public static final String BLACK_UNDERLINED = "\033[4;30m";  // BLACK
+  public static final String RED_UNDERLINED = "\033[4;31m";    // RED
+  public static final String GREEN_UNDERLINED = "\033[4;32m";  // GREEN
+  public static final String YELLOW_UNDERLINED = "\033[4;33m"; // YELLOW
+  public static final String BLUE_UNDERLINED = "\033[4;34m";   // BLUE
+  public static final String PURPLE_UNDERLINED = "\033[4;35m"; // PURPLE
+  public static final String CYAN_UNDERLINED = "\033[4;36m";   // CYAN
+  public static final String WHITE_UNDERLINED = "\033[4;37m";  // WHITE
+
+  // Background
+  public static final String BLACK_BACKGROUND = "\033[40m";  // BLACK
+  public static final String RED_BACKGROUND = "\033[41m";    // RED
+  public static final String GREEN_BACKGROUND = "\033[42m";  // GREEN
+  public static final String YELLOW_BACKGROUND = "\033[43m"; // YELLOW
+  public static final String BLUE_BACKGROUND = "\033[44m";   // BLUE
+  public static final String PURPLE_BACKGROUND = "\033[45m"; // PURPLE
+  public static final String CYAN_BACKGROUND = "\033[46m";   // CYAN
+  public static final String WHITE_BACKGROUND = "\033[47m";  // WHITE
+
+  // High Intensity
+  public static final String BLACK_BRIGHT = "\033[0;90m";  // BLACK
+  public static final String RED_BRIGHT = "\033[0;91m";    // RED
+  public static final String GREEN_BRIGHT = "\033[0;92m";  // GREEN
+  public static final String YELLOW_BRIGHT = "\033[0;93m"; // YELLOW
+  public static final String BLUE_BRIGHT = "\033[0;94m";   // BLUE
+  public static final String PURPLE_BRIGHT = "\033[0;95m"; // PURPLE
+  public static final String CYAN_BRIGHT = "\033[0;96m";   // CYAN
+  public static final String WHITE_BRIGHT = "\033[0;97m";  // WHITE
+
+  // Bold High Intensity
+  public static final String BLACK_BOLD_BRIGHT = "\033[1;90m"; // BLACK
+  public static final String RED_BOLD_BRIGHT = "\033[1;91m";   // RED
+  public static final String GREEN_BOLD_BRIGHT = "\033[1;92m"; // GREEN
+  public static final String YELLOW_BOLD_BRIGHT = "\033[1;93m";// YELLOW
+  public static final String BLUE_BOLD_BRIGHT = "\033[1;94m";  // BLUE
+  public static final String PURPLE_BOLD_BRIGHT = "\033[1;95m";// PURPLE
+  public static final String CYAN_BOLD_BRIGHT = "\033[1;96m";  // CYAN
+  public static final String WHITE_BOLD_BRIGHT = "\033[1;97m"; // WHITE
+
+  // High Intensity backgrounds
+  public static final String BLACK_BACKGROUND_BRIGHT = "\033[0;100m";// BLACK
+  public static final String RED_BACKGROUND_BRIGHT = "\033[0;101m";// RED
+  public static final String GREEN_BACKGROUND_BRIGHT = "\033[0;102m";// GREEN
+  public static final String YELLOW_BACKGROUND_BRIGHT = "\033[0;103m";// YELLOW
+  public static final String BLUE_BACKGROUND_BRIGHT = "\033[0;104m";// BLUE
+  public static final String PURPLE_BACKGROUND_BRIGHT = "\033[0;105m"; // PURPLE
+  public static final String CYAN_BACKGROUND_BRIGHT = "\033[0;106m";  // CYAN
+  public static final String WHITE_BACKGROUND_BRIGHT = "\033[0;107m";   // WHITE
+}

--- a/src/main/java/org/apache/ibatis/migration/ConsoleColors.java
+++ b/src/main/java/org/apache/ibatis/migration/ConsoleColors.java
@@ -17,77 +17,76 @@ package org.apache.ibatis.migration;
 
 // Credit: https://stackoverflow.com/a/45444716
 
-public class ConsoleColors {
-  // Reset
-  public static final String RESET = "\033[0m";  // Text Reset
+interface ConsoleColors {
+  String RESET = "\033[0m";  // Text Reset
 
   // Regular Colors
-  public static final String BLACK = "\033[0;30m";   // BLACK
-  public static final String RED = "\033[0;31m";     // RED
-  public static final String GREEN = "\033[0;32m";   // GREEN
-  public static final String YELLOW = "\033[0;33m";  // YELLOW
-  public static final String BLUE = "\033[0;34m";    // BLUE
-  public static final String PURPLE = "\033[0;35m";  // PURPLE
-  public static final String CYAN = "\033[0;36m";    // CYAN
-  public static final String WHITE = "\033[0;37m";   // WHITE
+  String BLACK = "\033[0;30m";   // BLACK
+  String RED = "\033[0;31m";     // RED
+  String GREEN = "\033[0;32m";   // GREEN
+  String YELLOW = "\033[0;33m";  // YELLOW
+  String BLUE = "\033[0;34m";    // BLUE
+  String PURPLE = "\033[0;35m";  // PURPLE
+  String CYAN = "\033[0;36m";    // CYAN
+  String WHITE = "\033[0;37m";   // WHITE
 
   // Bold
-  public static final String BLACK_BOLD = "\033[1;30m";  // BLACK
-  public static final String RED_BOLD = "\033[1;31m";    // RED
-  public static final String GREEN_BOLD = "\033[1;32m";  // GREEN
-  public static final String YELLOW_BOLD = "\033[1;33m"; // YELLOW
-  public static final String BLUE_BOLD = "\033[1;34m";   // BLUE
-  public static final String PURPLE_BOLD = "\033[1;35m"; // PURPLE
-  public static final String CYAN_BOLD = "\033[1;36m";   // CYAN
-  public static final String WHITE_BOLD = "\033[1;37m";  // WHITE
+  String BLACK_BOLD = "\033[1;30m";  // BLACK
+  String RED_BOLD = "\033[1;31m";    // RED
+  String GREEN_BOLD = "\033[1;32m";  // GREEN
+  String YELLOW_BOLD = "\033[1;33m"; // YELLOW
+  String BLUE_BOLD = "\033[1;34m";   // BLUE
+  String PURPLE_BOLD = "\033[1;35m"; // PURPLE
+  String CYAN_BOLD = "\033[1;36m";   // CYAN
+  String WHITE_BOLD = "\033[1;37m";  // WHITE
 
   // Underline
-  public static final String BLACK_UNDERLINED = "\033[4;30m";  // BLACK
-  public static final String RED_UNDERLINED = "\033[4;31m";    // RED
-  public static final String GREEN_UNDERLINED = "\033[4;32m";  // GREEN
-  public static final String YELLOW_UNDERLINED = "\033[4;33m"; // YELLOW
-  public static final String BLUE_UNDERLINED = "\033[4;34m";   // BLUE
-  public static final String PURPLE_UNDERLINED = "\033[4;35m"; // PURPLE
-  public static final String CYAN_UNDERLINED = "\033[4;36m";   // CYAN
-  public static final String WHITE_UNDERLINED = "\033[4;37m";  // WHITE
+  String BLACK_UNDERLINED = "\033[4;30m";  // BLACK
+  String RED_UNDERLINED = "\033[4;31m";    // RED
+  String GREEN_UNDERLINED = "\033[4;32m";  // GREEN
+  String YELLOW_UNDERLINED = "\033[4;33m"; // YELLOW
+  String BLUE_UNDERLINED = "\033[4;34m";   // BLUE
+  String PURPLE_UNDERLINED = "\033[4;35m"; // PURPLE
+  String CYAN_UNDERLINED = "\033[4;36m";   // CYAN
+  String WHITE_UNDERLINED = "\033[4;37m";  // WHITE
 
   // Background
-  public static final String BLACK_BACKGROUND = "\033[40m";  // BLACK
-  public static final String RED_BACKGROUND = "\033[41m";    // RED
-  public static final String GREEN_BACKGROUND = "\033[42m";  // GREEN
-  public static final String YELLOW_BACKGROUND = "\033[43m"; // YELLOW
-  public static final String BLUE_BACKGROUND = "\033[44m";   // BLUE
-  public static final String PURPLE_BACKGROUND = "\033[45m"; // PURPLE
-  public static final String CYAN_BACKGROUND = "\033[46m";   // CYAN
-  public static final String WHITE_BACKGROUND = "\033[47m";  // WHITE
+  String BLACK_BACKGROUND = "\033[40m";  // BLACK
+  String RED_BACKGROUND = "\033[41m";    // RED
+  String GREEN_BACKGROUND = "\033[42m";  // GREEN
+  String YELLOW_BACKGROUND = "\033[43m"; // YELLOW
+  String BLUE_BACKGROUND = "\033[44m";   // BLUE
+  String PURPLE_BACKGROUND = "\033[45m"; // PURPLE
+  String CYAN_BACKGROUND = "\033[46m";   // CYAN
+  String WHITE_BACKGROUND = "\033[47m";  // WHITE
 
   // High Intensity
-  public static final String BLACK_BRIGHT = "\033[0;90m";  // BLACK
-  public static final String RED_BRIGHT = "\033[0;91m";    // RED
-  public static final String GREEN_BRIGHT = "\033[0;92m";  // GREEN
-  public static final String YELLOW_BRIGHT = "\033[0;93m"; // YELLOW
-  public static final String BLUE_BRIGHT = "\033[0;94m";   // BLUE
-  public static final String PURPLE_BRIGHT = "\033[0;95m"; // PURPLE
-  public static final String CYAN_BRIGHT = "\033[0;96m";   // CYAN
-  public static final String WHITE_BRIGHT = "\033[0;97m";  // WHITE
+  String BLACK_BRIGHT = "\033[0;90m";  // BLACK
+  String RED_BRIGHT = "\033[0;91m";    // RED
+  String GREEN_BRIGHT = "\033[0;92m";  // GREEN
+  String YELLOW_BRIGHT = "\033[0;93m"; // YELLOW
+  String BLUE_BRIGHT = "\033[0;94m";   // BLUE
+  String PURPLE_BRIGHT = "\033[0;95m"; // PURPLE
+  String CYAN_BRIGHT = "\033[0;96m";   // CYAN
+  String WHITE_BRIGHT = "\033[0;97m";  // WHITE
 
   // Bold High Intensity
-  public static final String BLACK_BOLD_BRIGHT = "\033[1;90m"; // BLACK
-  public static final String RED_BOLD_BRIGHT = "\033[1;91m";   // RED
-  public static final String GREEN_BOLD_BRIGHT = "\033[1;92m"; // GREEN
-  public static final String YELLOW_BOLD_BRIGHT = "\033[1;93m";// YELLOW
-  public static final String BLUE_BOLD_BRIGHT = "\033[1;94m";  // BLUE
-  public static final String PURPLE_BOLD_BRIGHT = "\033[1;95m";// PURPLE
-  public static final String CYAN_BOLD_BRIGHT = "\033[1;96m";  // CYAN
-  public static final String WHITE_BOLD_BRIGHT = "\033[1;97m"; // WHITE
+  String BLACK_BOLD_BRIGHT = "\033[1;90m"; // BLACK
+  String RED_BOLD_BRIGHT = "\033[1;91m";   // RED
+  String GREEN_BOLD_BRIGHT = "\033[1;92m"; // GREEN
+  String YELLOW_BOLD_BRIGHT = "\033[1;93m";// YELLOW
+  String BLUE_BOLD_BRIGHT = "\033[1;94m";  // BLUE
+  String PURPLE_BOLD_BRIGHT = "\033[1;95m";// PURPLE
+  String CYAN_BOLD_BRIGHT = "\033[1;96m";  // CYAN
+  String WHITE_BOLD_BRIGHT = "\033[1;97m"; // WHITE
 
   // High Intensity backgrounds
-  public static final String BLACK_BACKGROUND_BRIGHT = "\033[0;100m";// BLACK
-  public static final String RED_BACKGROUND_BRIGHT = "\033[0;101m";// RED
-  public static final String GREEN_BACKGROUND_BRIGHT = "\033[0;102m";// GREEN
-  public static final String YELLOW_BACKGROUND_BRIGHT = "\033[0;103m";// YELLOW
-  public static final String BLUE_BACKGROUND_BRIGHT = "\033[0;104m";// BLUE
-  public static final String PURPLE_BACKGROUND_BRIGHT = "\033[0;105m"; // PURPLE
-  public static final String CYAN_BACKGROUND_BRIGHT = "\033[0;106m";  // CYAN
-  public static final String WHITE_BACKGROUND_BRIGHT = "\033[0;107m";   // WHITE
+  String BLACK_BACKGROUND_BRIGHT = "\033[0;100m";// BLACK
+  String RED_BACKGROUND_BRIGHT = "\033[0;101m";// RED
+  String GREEN_BACKGROUND_BRIGHT = "\033[0;102m";// GREEN
+  String YELLOW_BACKGROUND_BRIGHT = "\033[0;103m";// YELLOW
+  String BLUE_BACKGROUND_BRIGHT = "\033[0;104m";// BLUE
+  String PURPLE_BACKGROUND_BRIGHT = "\033[0;105m"; // PURPLE
+  String CYAN_BACKGROUND_BRIGHT = "\033[0;106m";  // CYAN
+  String WHITE_BACKGROUND_BRIGHT = "\033[0;107m";   // WHITE
 }

--- a/src/main/java/org/apache/ibatis/migration/options/Options.java
+++ b/src/main/java/org/apache/ibatis/migration/options/Options.java
@@ -27,5 +27,6 @@ public enum Options {
   HELP,
   TEMPLATE,
   IDPATTERN,
-  QUIET
+  QUIET,
+  COLOR
 }

--- a/src/main/java/org/apache/ibatis/migration/options/OptionsParser.java
+++ b/src/main/java/org/apache/ibatis/migration/options/OptionsParser.java
@@ -90,6 +90,9 @@ public enum OptionsParser {
         case QUIET:
           options.setQuiet(true);
           break;
+        case COLOR:
+          options.setColor(true);
+          break;
       }
     }
 

--- a/src/main/java/org/apache/ibatis/migration/options/SelectedOptions.java
+++ b/src/main/java/org/apache/ibatis/migration/options/SelectedOptions.java
@@ -32,7 +32,7 @@ public class SelectedOptions {
     return quiet;
   }
 
-  public boolean isColor() {
+  public boolean hasColor() {
     return color;
   }
 

--- a/src/main/java/org/apache/ibatis/migration/options/SelectedOptions.java
+++ b/src/main/java/org/apache/ibatis/migration/options/SelectedOptions.java
@@ -25,11 +25,19 @@ public class SelectedOptions {
   private String command;
   private String params;
   private boolean help;
-
   private boolean quiet;
+  private boolean color;
 
   public boolean isQuiet() {
     return quiet;
+  }
+
+  public boolean isColor() {
+    return color;
+  }
+
+  public void setColor(boolean color) {
+    this.color = color;
   }
 
   public void setQuiet(boolean quiet) {


### PR DESCRIPTION
I want to bounce some ideas if it makes sense to enhance the tool to visually give (more) feedback on passing or broken migrations (similar to most test frameworks red->green schema)
I usually let the tool run and continue on something else - i still notice that the log is moving and for me it helped that it spitted out a red text on a failure as this usually gets my attention immediately.

In our internal version of mybatis-migrations we also red-color the exception to separate them from the migration content that is also printed out and made the tool less chatty by removing the status lines. If you run many and large migrations it helps to quickly jump to a red part and see what was wrong as you tend to lose where the error started.

Nonetheless. I stripped our version down to just printing the SUCCESS or FAILURE, exceptions in different colors to have a small increment and hope we can just build-up from there.

Activate it by adding "--color" as a parameter.

(pom.xml change was done to build locally)