### PR TITLE
Allow users to use their own implementation of FileMigrationLoader. R…

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/FileMigrationLoader.java
+++ b/src/main/java/org/apache/ibatis/migration/FileMigrationLoader.java
@@ -27,11 +27,11 @@ import java.util.Properties;
 import org.apache.ibatis.migration.utils.Util;
 
 public class FileMigrationLoader implements MigrationLoader {
-  private final File scriptsDir;
+  protected final File scriptsDir;
 
-  private final String charset;
+  protected final String charset;
 
-  private final Properties variables;
+  protected final Properties variables;
 
   public FileMigrationLoader(File scriptsDir, String charset, Properties variables) {
     super();
@@ -59,11 +59,11 @@ public class FileMigrationLoader implements MigrationLoader {
     return migrations;
   }
 
-  private boolean isSpecialFile(String filename) {
+  protected boolean isSpecialFile(String filename) {
     return "bootstrap.sql".equals(filename) || "onabort.sql".equals(filename);
   }
 
-  private Change parseChangeFromFilename(String filename) {
+  protected Change parseChangeFromFilename(String filename) {
     try {
       Change change = new Change();
       int lastIndexOfDot = filename.lastIndexOf(".");
@@ -105,7 +105,7 @@ public class FileMigrationLoader implements MigrationLoader {
     return getSoleScriptReader(fileName);
   }
 
-  private Reader getSoleScriptReader(String fileName) {
+  protected Reader getSoleScriptReader(String fileName) {
     try {
       File scriptFile = Util.file(scriptsDir, fileName);
       if (scriptFile.exists()) {

--- a/src/main/java/org/apache/ibatis/migration/FileMigrationLoaderFactory.java
+++ b/src/main/java/org/apache/ibatis/migration/FileMigrationLoaderFactory.java
@@ -1,0 +1,23 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.migration;
+
+import java.io.File;
+import java.util.Properties;
+
+public interface FileMigrationLoaderFactory {
+  MigrationLoader create(File scriptsDir, String charset, Properties variables);
+}


### PR DESCRIPTION
…elated to #93 #102 .

To use a custom FileMigrationLoader, you need to ...

1. create an implementation of `FileMigrationLoaderFactory`.
2. create a JAR including a file `/META-INF/services/org.apache.ibatis.migration.FileMigrationLoaderFactory` that contains fully-qualified name of the custom implementation (Migrations looks for a custom implementation via Java Service Provider Interface).
3. drop the JAR file in `$MIGRATIONS_HOME/lib` directory.

Please see these examples (not tested thoroughly!).

- https://github.com/harawata/bootstrap-dir for #93
- https://github.com/harawata/custom-file-migration-loader for #102

@h3adache ,
I'm so sorry to keep bothering you, but could you please see if this change is acceptable or not when you have time?
Thanks in advance!