### PR TITLE
Print warnings when there is a skipped migration or a missing migration script

### DIFF
--- a/src/test/java/org/apache/ibatis/migration/example/scripts/20080827200216_create_procs.sql
+++ b/src/test/java/org/apache/ibatis/migration/example/scripts/20080827200216_create_procs.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2010-2016 the original author or authors.
+--    Copyright 2010-2018 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/migration/example/scripts/20080827200217_parse_file_with_dot_._in_file_name.sql
+++ b/src/test/java/org/apache/ibatis/migration/example/scripts/20080827200217_parse_file_with_dot_._in_file_name.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2010-2016 the original author or authors.
+--    Copyright 2010-2018 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.


### PR DESCRIPTION
On up/down operation, Migrations will print warnings if...

- there is a migration script that 1) is not applied to the database and 2) has a lower ID than the latest applied migration (= skipped migration).
- there is an entry in the changelog table which has no corresponding script file in the scripts directory (= missing script).

This should fix #123 .