### PR TITLE
Allow more flexible environment settings

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/Environment.java
+++ b/src/main/java/org/apache/ibatis/migration/Environment.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2018 the original author or authors.
+ *    Copyright 2010-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map.Entry;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 public class Environment {
 
@@ -60,7 +60,7 @@ public class Environment {
   private static final List<String> SETTING_KEYS;
 
   static {
-    ArrayList<String> list = new ArrayList<String>();
+    ArrayList<String> list = new ArrayList<>();
     SETTING_KEY[] keys = SETTING_KEY.values();
     for (SETTING_KEY key : keys) {
       list.add(key.name());
@@ -94,63 +94,75 @@ public class Environment {
   private final String hookBeforeNew;
   private final String hookAfterNew;
 
+  /**
+   * Prefix used to lookup environment variable or system property.
+   */
+  private static final String PREFIX = "MIGRATIONS_";
+  private final Map<String, String> envVars = System.getenv();
+  private final Properties sysProps = System.getProperties();
   private final Properties variables = new Properties();
 
   public Environment(File file) {
-    FileInputStream inputStream = null;
-    try {
-      inputStream = new FileInputStream(file);
+    try (FileInputStream inputStream = new FileInputStream(file)) {
       Properties prop = new Properties();
       prop.load(inputStream);
 
-      this.timeZone = prop.getProperty(SETTING_KEY.time_zone.name(), "GMT+0:00");
-      this.delimiter = prop.getProperty(SETTING_KEY.delimiter.name(), ";");
-      this.scriptCharset = prop.getProperty(SETTING_KEY.script_char_set.name(), Charset.defaultCharset().name());
-      this.fullLineDelimiter = Boolean.valueOf(prop.getProperty(SETTING_KEY.full_line_delimiter.name()));
-      this.sendFullScript = Boolean.valueOf(prop.getProperty(SETTING_KEY.send_full_script.name()));
-      this.autoCommit = Boolean.valueOf(prop.getProperty(SETTING_KEY.auto_commit.name()));
-      this.removeCrs = Boolean.valueOf(prop.getProperty(SETTING_KEY.remove_crs.name()));
-      this.ignoreWarnings = Boolean.valueOf(prop.getProperty(SETTING_KEY.ignore_warnings.name(), "true"));
+      this.timeZone = readProperty(prop, SETTING_KEY.time_zone.name(), "GMT+0:00");
+      this.delimiter = readProperty(prop, SETTING_KEY.delimiter.name(), ";");
+      this.scriptCharset = readProperty(prop, SETTING_KEY.script_char_set.name(), Charset.defaultCharset().name());
+      this.fullLineDelimiter = Boolean.valueOf(readProperty(prop, SETTING_KEY.full_line_delimiter.name()));
+      this.sendFullScript = Boolean.valueOf(readProperty(prop, SETTING_KEY.send_full_script.name()));
+      this.autoCommit = Boolean.valueOf(readProperty(prop, SETTING_KEY.auto_commit.name()));
+      this.removeCrs = Boolean.valueOf(readProperty(prop, SETTING_KEY.remove_crs.name()));
+      this.ignoreWarnings = Boolean.valueOf(readProperty(prop, SETTING_KEY.ignore_warnings.name(), "true"));
 
-      this.driverPath = prop.getProperty(SETTING_KEY.driver_path.name());
-      this.driver = prop.getProperty(SETTING_KEY.driver.name());
-      this.url = prop.getProperty(SETTING_KEY.url.name());
-      this.username = prop.getProperty(SETTING_KEY.username.name());
-      this.password = prop.getProperty(SETTING_KEY.password.name());
+      this.driverPath = readProperty(prop, SETTING_KEY.driver_path.name());
+      this.driver = readProperty(prop, SETTING_KEY.driver.name());
+      this.url = readProperty(prop, SETTING_KEY.url.name());
+      this.username = readProperty(prop, SETTING_KEY.username.name());
+      this.password = readProperty(prop, SETTING_KEY.password.name());
 
-      this.hookBeforeUp = prop.getProperty(SETTING_KEY.hook_before_up.name());
-      this.hookBeforeEachUp = prop.getProperty(SETTING_KEY.hook_before_each_up.name());
-      this.hookAfterEachUp = prop.getProperty(SETTING_KEY.hook_after_each_up.name());
-      this.hookAfterUp = prop.getProperty(SETTING_KEY.hook_after_up.name());
-      this.hookBeforeDown = prop.getProperty(SETTING_KEY.hook_before_down.name());
-      this.hookBeforeEachDown = prop.getProperty(SETTING_KEY.hook_before_each_down.name());
-      this.hookAfterEachDown = prop.getProperty(SETTING_KEY.hook_after_each_down.name());
-      this.hookAfterDown = prop.getProperty(SETTING_KEY.hook_after_down.name());
+      this.hookBeforeUp = readProperty(prop, SETTING_KEY.hook_before_up.name());
+      this.hookBeforeEachUp = readProperty(prop, SETTING_KEY.hook_before_each_up.name());
+      this.hookAfterEachUp = readProperty(prop, SETTING_KEY.hook_after_each_up.name());
+      this.hookAfterUp = readProperty(prop, SETTING_KEY.hook_after_up.name());
+      this.hookBeforeDown = readProperty(prop, SETTING_KEY.hook_before_down.name());
+      this.hookBeforeEachDown = readProperty(prop, SETTING_KEY.hook_before_each_down.name());
+      this.hookAfterEachDown = readProperty(prop, SETTING_KEY.hook_after_each_down.name());
+      this.hookAfterDown = readProperty(prop, SETTING_KEY.hook_after_down.name());
 
-      this.hookBeforeNew = prop.getProperty(SETTING_KEY.hook_before_new.name());
-      this.hookAfterNew = prop.getProperty(SETTING_KEY.hook_after_new.name());
+      this.hookBeforeNew = readProperty(prop, SETTING_KEY.hook_before_new.name());
+      this.hookAfterNew = readProperty(prop, SETTING_KEY.hook_after_new.name());
 
       // User defined variables.
-      Set<Entry<Object, Object>> entries = prop.entrySet();
-      for (Entry<Object, Object> entry : entries) {
-        String key = (String) entry.getKey();
-        if (!SETTING_KEYS.contains(key)) {
-          variables.put(key, entry.getValue());
-        }
-      }
+      prop.entrySet().stream().filter(e -> !SETTING_KEYS.contains(e.getKey())).forEach(e -> {
+        variables.put(e.getKey(), e.getValue());
+      });
     } catch (FileNotFoundException e) {
       throw new MigrationException("Environment file missing: " + file.getAbsolutePath());
     } catch (IOException e) {
       throw new MigrationException("Error loading environment properties.  Cause: " + e, e);
-    } finally {
-      if (inputStream != null) {
-        try {
-          inputStream.close();
-        } catch (IOException e) {
-          // ignore
-        }
-      }
     }
+  }
+
+  protected String readProperty(Properties properties, String propertyKey) {
+    return readProperty(properties, propertyKey, null);
+  }
+
+  protected String readProperty(Properties properties, String propertyKey, String defaultValue) {
+    // 1. Check system properties with prefix.
+    String property = sysProps.getProperty(PREFIX + propertyKey.toUpperCase(Locale.ENGLISH));
+    if (property != null) {
+      return property;
+    }
+    // 2. Check environment variables with prefix.
+    property = envVars.get(PREFIX + propertyKey.toUpperCase(Locale.ENGLISH));
+    if (property != null) {
+      return property;
+    }
+    // 3. Read .properties file with variable replacement.
+    property = properties.getProperty(propertyKey, defaultValue);
+    return property == null ? null : property;
   }
 
   public String getTimeZone() {

--- a/src/test/java/org/apache/ibatis/migration/system_property/SystemPropertyTest.java
+++ b/src/test/java/org/apache/ibatis/migration/system_property/SystemPropertyTest.java
@@ -58,6 +58,9 @@ public class SystemPropertyTest {
     System.setProperty("MIGRATIONS_DRIVER", "org.hsqldb.jdbcDriver");
     System.setProperty("username", "Pocahontas");
     System.setProperty("var1", "Variable 1");
+    System.setProperty("MIGRATIONS_VAR3", "Variable 3");
+    System.setProperty("migrations_var4", "Variable 4");
+    System.setProperty("MIGRATIONS_VAR5", "Variable 5");
 
     Migrator.main(TestUtil.args("--path=" + dir.getAbsolutePath(), "up", "1", "--trace"));
 
@@ -66,6 +69,10 @@ public class SystemPropertyTest {
     assertTrue(output.contains("username: Pocahontas"));
     assertTrue(output.contains("var1: Variable 1"));
     assertTrue(output.contains("var2: ${var2}"));
+    assertTrue(output.contains("var3: Variable 3"));
+    assertTrue(output.contains("var4: Variable 4"));
+    assertTrue(output.contains("var5: Variable 5"));
+    assertTrue(output.contains("Var5: Var5 in properties file"));
 
     out.clearLog();
     System.exit(0);

--- a/src/test/java/org/apache/ibatis/migration/system_property/SystemPropertyTest.java
+++ b/src/test/java/org/apache/ibatis/migration/system_property/SystemPropertyTest.java
@@ -1,0 +1,68 @@
+/**
+ *    Copyright 2010-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.migration.system_property;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.migration.Migrator;
+import org.apache.ibatis.migration.utils.TestUtil;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.Assertion;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+public class SystemPropertyTest {
+
+  @Rule
+  public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+  @Rule
+  public final SystemOutRule out = new SystemOutRule().enableLog();
+
+  private static File dir;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    dir = Resources.getResourceAsFile("org/apache/ibatis/migration/system_property/testdir");
+  }
+
+  @Test
+  public void testSystemProperties() throws Exception {
+    exit.expectSystemExit();
+    exit.checkAssertionAfterwards(new Assertion() {
+      public void checkAssertion() {
+        assertEquals("", out.getLog());
+      }
+    });
+    out.clearLog();
+
+    // Set system properties
+    System.setProperty("MIGRATIONS_DRIVER", "org.hsqldb.jdbcDriver");
+
+    Migrator.main(TestUtil.args("--path=" + dir.getAbsolutePath(), "up", "1", "--trace"));
+
+    String output = out.getLog();
+    assertTrue(output.contains("SUCCESS"));
+
+    out.clearLog();
+    System.exit(0);
+  }
+}

--- a/src/test/java/org/apache/ibatis/migration/system_property/SystemPropertyTest.java
+++ b/src/test/java/org/apache/ibatis/migration/system_property/SystemPropertyTest.java
@@ -56,11 +56,16 @@ public class SystemPropertyTest {
 
     // Set system properties
     System.setProperty("MIGRATIONS_DRIVER", "org.hsqldb.jdbcDriver");
+    System.setProperty("username", "Pocahontas");
+    System.setProperty("var1", "Variable 1");
 
     Migrator.main(TestUtil.args("--path=" + dir.getAbsolutePath(), "up", "1", "--trace"));
 
     String output = out.getLog();
     assertTrue(output.contains("SUCCESS"));
+    assertTrue(output.contains("username: Pocahontas"));
+    assertTrue(output.contains("var1: Variable 1"));
+    assertTrue(output.contains("var2: ${var2}"));
 
     out.clearLog();
     System.exit(0);

--- a/src/test/java/org/apache/ibatis/migration/system_property/testdir/environments/development.properties
+++ b/src/test/java/org/apache/ibatis/migration/system_property/testdir/environments/development.properties
@@ -16,7 +16,10 @@
 
 driver=should_be_overwritten_by_system_property
 url=jdbc:hsqldb:mem:sysprop
-username=Pocahontas
+username=${username}
 password=
 
 changelog=CHANGELOG
+
+var1=${var1}
+var2=${var2}

--- a/src/test/java/org/apache/ibatis/migration/system_property/testdir/environments/development.properties
+++ b/src/test/java/org/apache/ibatis/migration/system_property/testdir/environments/development.properties
@@ -1,0 +1,22 @@
+#
+#    Copyright 2010-2019 the original author or authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+driver=should_be_overwritten_by_system_property
+url=jdbc:hsqldb:mem:sysprop
+username=Pocahontas
+password=
+
+changelog=CHANGELOG

--- a/src/test/java/org/apache/ibatis/migration/system_property/testdir/environments/development.properties
+++ b/src/test/java/org/apache/ibatis/migration/system_property/testdir/environments/development.properties
@@ -23,3 +23,5 @@ changelog=CHANGELOG
 
 var1=${var1}
 var2=${var2}
+var4=should be overwritten by system property
+Var5=Var5 in properties file

--- a/src/test/java/org/apache/ibatis/migration/system_property/testdir/scripts/001_create_changelog.sql
+++ b/src/test/java/org/apache/ibatis/migration/system_property/testdir/scripts/001_create_changelog.sql
@@ -38,6 +38,10 @@ PRIMARY KEY (id);
 SELECT 'username: ' || USER_NAME FROM INFORMATION_SCHEMA.SYSTEM_USERS;
 SELECT 'var1: ' || '${var1}' FROM (VALUES(0));
 SELECT 'var2: ' || '${var2}' FROM (VALUES(0));
+SELECT 'var3: ' || '${var3}' FROM (VALUES(0));
+SELECT 'var4: ' || '${var4}' FROM (VALUES(0));
+SELECT 'var5: ' || '${var5}' FROM (VALUES(0));
+SELECT 'Var5: ' || '${Var5}' FROM (VALUES(0));
 
 
 -- //@UNDO

--- a/src/test/java/org/apache/ibatis/migration/system_property/testdir/scripts/001_create_changelog.sql
+++ b/src/test/java/org/apache/ibatis/migration/system_property/testdir/scripts/001_create_changelog.sql
@@ -1,0 +1,41 @@
+--
+--    Copyright 2010-2019 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+-- // Create Changelog
+
+-- Default DDL for changelog table that will keep
+-- a record of the migrations that have been run.
+
+-- You can modify this to suit your database before
+-- running your first migration.
+
+-- Be sure that ID and DESCRIPTION fields exist in
+-- BigInteger and String compatible fields respectively.
+
+CREATE TABLE ${changelog} (
+ID NUMERIC(20,0) NOT NULL,
+APPLIED_AT VARCHAR(25) NOT NULL,
+DESCRIPTION VARCHAR(255) NOT NULL
+);
+
+ALTER TABLE ${changelog}
+ADD CONSTRAINT PK_${changelog}
+PRIMARY KEY (id);
+
+
+-- //@UNDO
+
+DROP TABLE ${changelog};

--- a/src/test/java/org/apache/ibatis/migration/system_property/testdir/scripts/001_create_changelog.sql
+++ b/src/test/java/org/apache/ibatis/migration/system_property/testdir/scripts/001_create_changelog.sql
@@ -35,6 +35,10 @@ ALTER TABLE ${changelog}
 ADD CONSTRAINT PK_${changelog}
 PRIMARY KEY (id);
 
+SELECT 'username: ' || USER_NAME FROM INFORMATION_SCHEMA.SYSTEM_USERS;
+SELECT 'var1: ' || '${var1}' FROM (VALUES(0));
+SELECT 'var2: ' || '${var2}' FROM (VALUES(0));
+
 
 -- //@UNDO
 


### PR DESCRIPTION
1. Migrations can read environment settings from environment variables or system properties.
2. In the properties file, variable expressions `${}` are replaced if there is a matching system property or environment variable.

Regarding 1 ...
- Settings are read in the following order of priority (high to low)
   1. System property
   2. Environment variable
   3. Properties file
- System property and environment variable must be declared under the name with prefix (e.g. `MIGRATIONS_USERNAME`, `MIGRATIONS_PASSWORD`).

Should close #114 and replace #128 and #144 .