### PR TITLE
Revise usage of core classes

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/MigrationException.java
+++ b/src/main/java/org/apache/ibatis/migration/MigrationException.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2017 the original author or authors.
+ *    Copyright 2010-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,9 +15,7 @@
  */
 package org.apache.ibatis.migration;
 
-import org.apache.ibatis.exceptions.PersistenceException;
-
-public class MigrationException extends PersistenceException {
+public class MigrationException extends RuntimeException {
 
   private static final long serialVersionUID = 491769430730827896L;
 

--- a/src/main/java/org/apache/ibatis/migration/MigrationReader.java
+++ b/src/main/java/org/apache/ibatis/migration/MigrationReader.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2019 the original author or authors.
+ *    Copyright 2010-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Properties;
-
-import org.apache.ibatis.parsing.PropertyParser;
 
 public class MigrationReader extends FilterReader {
 
@@ -56,6 +54,8 @@ public class MigrationReader extends FilterReader {
 
   private final StringBuilder lineBuffer = new StringBuilder();
 
+  private final VariableReplacer replacer;
+
   private enum Part {
     NOT_UNDO_LINE,
     NEW_LINE,
@@ -83,6 +83,7 @@ public class MigrationReader extends FilterReader {
     super(scriptFileReader(inputStream, charset));
     this.undo = undo;
     this.variables = variables;
+    replacer = new VariableReplacer(this.variables);
   }
 
   @Override
@@ -161,7 +162,7 @@ public class MigrationReader extends FilterReader {
   private void replaceVariables(StringBuilder line) {
     if (variableStatus == VariableStatus.FOUND_POSSIBLE_VARIABLE) {
       String lineBufferStr = line.toString();
-      String processed = PropertyParser.parse(lineBufferStr, variables);
+      String processed = replacer.replace(lineBufferStr);
       if (!lineBufferStr.equals(processed)) {
         line.setLength(0);
         line.append(processed);

--- a/src/main/java/org/apache/ibatis/migration/VariableReplacer.java
+++ b/src/main/java/org/apache/ibatis/migration/VariableReplacer.java
@@ -1,0 +1,113 @@
+/**
+ *    Copyright 2010-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.migration;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * @author Clinton Begin
+ */
+public class VariableReplacer {
+
+  private static final String openToken = "${";
+  private static final String closeToken = "}";
+  private final List<Map<? extends Object, ? extends Object>> variablesList;
+
+  public VariableReplacer(Map<? extends Object, ? extends Object> variablesList) {
+    this(Arrays.asList(variablesList));
+  }
+
+  public VariableReplacer(List<Map<? extends Object, ? extends Object>> variablesList) {
+    this.variablesList = variablesList == null ? Collections.emptyList()
+        : variablesList.stream().filter(Objects::nonNull).collect(Collectors.toList());
+  }
+
+  public String replace(String text) {
+    if (text == null || text.isEmpty()) {
+      return "";
+    }
+    // search open token
+    int start = text.indexOf(openToken);
+    if (start == -1) {
+      return text;
+    }
+    char[] src = text.toCharArray();
+    int offset = 0;
+    final StringBuilder builder = new StringBuilder();
+    StringBuilder expression = null;
+    while (start > -1) {
+      if (start > 0 && src[start - 1] == '\\') {
+        // this open token is escaped. remove the backslash and continue.
+        builder.append(src, offset, start - offset - 1).append(openToken);
+        offset = start + openToken.length();
+      } else {
+        // found open token. let's search close token.
+        if (expression == null) {
+          expression = new StringBuilder();
+        } else {
+          expression.setLength(0);
+        }
+        builder.append(src, offset, start - offset);
+        offset = start + openToken.length();
+        int end = text.indexOf(closeToken, offset);
+        while (end > -1) {
+          if (end > offset && src[end - 1] == '\\') {
+            // this close token is escaped. remove the backslash and continue.
+            expression.append(src, offset, end - offset - 1).append(closeToken);
+            offset = end + closeToken.length();
+            end = text.indexOf(closeToken, offset);
+          } else {
+            expression.append(src, offset, end - offset);
+            break;
+          }
+        }
+        if (end == -1) {
+          // close token was not found.
+          builder.append(src, start, src.length - start);
+          offset = src.length;
+        } else {
+          appendWithReplace(builder, expression.toString());
+          offset = end + closeToken.length();
+        }
+      }
+      start = text.indexOf(openToken, offset);
+    }
+    if (offset < src.length) {
+      builder.append(src, offset, src.length - offset);
+    }
+    return builder.toString();
+  }
+
+  private StringBuilder appendWithReplace(StringBuilder builder, String key) {
+    String value = null;
+    for (Map<? extends Object, ? extends Object> variables : variablesList) {
+      value = (String) variables.get(key);
+      if (value != null) {
+        builder.append(value);
+        break;
+      }
+    }
+    if (value == null) {
+      builder.append(openToken).append(key).append(closeToken);
+    }
+    return builder;
+  }
+}

--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2018 the original author or authors.
+ *    Copyright 2010-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -38,14 +38,13 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.TimeZone;
 
-import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.ConnectionProvider;
-import org.apache.ibatis.migration.DataSourceConnectionProvider;
 import org.apache.ibatis.migration.Environment;
 import org.apache.ibatis.migration.FileMigrationLoader;
 import org.apache.ibatis.migration.FileMigrationLoaderFactory;
+import org.apache.ibatis.migration.JdbcConnectionProvider;
 import org.apache.ibatis.migration.MigrationException;
 import org.apache.ibatis.migration.MigrationLoader;
 import org.apache.ibatis.migration.hook.FileHookScriptFactory;
@@ -227,9 +226,8 @@ public abstract class BaseCommand implements Command {
 
   protected ConnectionProvider getConnectionProvider() {
     try {
-      UnpooledDataSource dataSource = new UnpooledDataSource(getDriverClassLoader(), environment().getDriver(),
-          environment().getUrl(), environment().getUsername(), environment().getPassword());
-      return new DataSourceConnectionProvider(dataSource);
+      return new JdbcConnectionProvider(environment().getDriver(), environment().getUrl(), environment().getUsername(),
+          environment().getPassword());
     } catch (Exception e) {
       throw new MigrationException("Error creating ScriptRunner.  Cause: " + e, e);
     }

--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -47,6 +47,7 @@ import org.apache.ibatis.migration.FileMigrationLoaderFactory;
 import org.apache.ibatis.migration.JdbcConnectionProvider;
 import org.apache.ibatis.migration.MigrationException;
 import org.apache.ibatis.migration.MigrationLoader;
+import org.apache.ibatis.migration.VariableReplacer;
 import org.apache.ibatis.migration.hook.FileHookScriptFactory;
 import org.apache.ibatis.migration.hook.FileMigrationHook;
 import org.apache.ibatis.migration.hook.HookScriptFactory;
@@ -56,7 +57,6 @@ import org.apache.ibatis.migration.options.Options;
 import org.apache.ibatis.migration.options.SelectedOptions;
 import org.apache.ibatis.migration.options.SelectedPaths;
 import org.apache.ibatis.migration.utils.Util;
-import org.apache.ibatis.parsing.PropertyParser;
 
 public abstract class BaseCommand implements Command {
   private static final String DATE_FORMAT = "yyyyMMddHHmmss";
@@ -174,13 +174,14 @@ public abstract class BaseCommand implements Command {
   }
 
   protected static void copyTemplate(Reader templateReader, File toFile, Properties variables) throws IOException {
+    VariableReplacer replacer = new VariableReplacer(variables);
     LineNumberReader reader = new LineNumberReader(templateReader);
     try {
       PrintWriter writer = new PrintWriter(new FileWriter(toFile));
       try {
         String line;
         while ((line = reader.readLine()) != null) {
-          line = PropertyParser.parse(line, variables);
+          line = replacer.replace(line);
           writer.println(line);
         }
       } finally {

--- a/src/main/java/org/apache/ibatis/migration/hook/HookContext.java
+++ b/src/main/java/org/apache/ibatis/migration/hook/HookContext.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2018 the original author or authors.
+ *    Copyright 2010-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.ConnectionProvider;
+import org.apache.ibatis.migration.operations.ScriptRunner;
 
 public class HookContext {
   private ConnectionProvider connectionProvider;

--- a/src/main/java/org/apache/ibatis/migration/hook/SqlHookScript.java
+++ b/src/main/java/org/apache/ibatis/migration/hook/SqlHookScript.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2017 the original author or authors.
+ *    Copyright 2010-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.ibatis.migration.MigrationException;
+import org.apache.ibatis.migration.VariableReplacer;
 import org.apache.ibatis.migration.utils.Util;
-import org.apache.ibatis.parsing.PropertyParser;
 
 public class SqlHookScript implements HookScript {
 
@@ -34,6 +34,7 @@ public class SqlHookScript implements HookScript {
   protected final String charset;
   protected final Properties variables;
   protected final PrintStream printStream;
+  protected final VariableReplacer replacer;
 
   public SqlHookScript(File scriptFile, String charset, String[] options, Properties variables,
       PrintStream printStream) {
@@ -49,6 +50,7 @@ public class SqlHookScript implements HookScript {
         this.variables.put(option.substring(0, sep), option.substring(sep + 1));
       }
     }
+    replacer = new VariableReplacer(this.variables);
   }
 
   @Override
@@ -65,7 +67,7 @@ public class SqlHookScript implements HookScript {
       while ((length = inputStream.read(buffer)) != -1) {
         outputStream.write(buffer, 0, length);
       }
-      context.executeSql(new StringReader(PropertyParser.parse(outputStream.toString(charset), variables)));
+      context.executeSql(new StringReader(replacer.replace(outputStream.toString(charset))));
     } catch (IOException e) {
       throw new MigrationException("Error occurred while running SQL hook script.", e);
     } finally {

--- a/src/main/java/org/apache/ibatis/migration/operations/BootstrapOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/BootstrapOperation.java
@@ -19,7 +19,6 @@ import java.io.PrintStream;
 import java.io.Reader;
 import java.sql.Connection;
 
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.migration.ConnectionProvider;
 import org.apache.ibatis.migration.MigrationException;
 import org.apache.ibatis.migration.MigrationLoader;

--- a/src/main/java/org/apache/ibatis/migration/operations/ChangelogOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/ChangelogOperation.java
@@ -1,0 +1,80 @@
+/**
+ *    Copyright 2010-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.migration.operations;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.ibatis.migration.Change;
+import org.apache.ibatis.migration.options.DatabaseOperationOption;
+
+public class ChangelogOperation {
+  private final Connection con;
+  private final DatabaseOperationOption option;
+
+  public ChangelogOperation(Connection con, DatabaseOperationOption option) {
+    super();
+    this.con = con;
+    this.option = option;
+  }
+
+  public boolean tableExists() {
+    try (Statement stmt = con.createStatement();
+        ResultSet rs = stmt.executeQuery("select count(1) from " + option.getChangelogTable())) {
+      return rs.next();
+    } catch (SQLException e) {
+      return false;
+    }
+  }
+
+  public List<Change> selectAll() throws SQLException {
+    List<Change> changes = new ArrayList<>();
+    try (
+        PreparedStatement stmt = con
+            .prepareStatement("select ID, APPLIED_AT, DESCRIPTION from " + option.getChangelogTable() + " order by ID");
+        ResultSet rs = stmt.executeQuery()) {
+      while (rs.next()) {
+        changes.add(new Change(rs.getBigDecimal(1), rs.getString(2), rs.getString(3)));
+      }
+      return changes;
+    }
+  }
+
+  public void insert(Change change) throws SQLException {
+    try (PreparedStatement stmt = con.prepareStatement(
+        "insert into " + option.getChangelogTable() + " (ID, APPLIED_AT, DESCRIPTION) values (?,?,?)")) {
+      stmt.setBigDecimal(1, change.getId());
+      stmt.setString(2, change.getAppliedTimestamp());
+      stmt.setString(3, change.getDescription());
+      stmt.execute();
+      con.commit();
+    }
+  }
+
+  public void deleteById(BigDecimal id) throws SQLException {
+    try (PreparedStatement stmt = con.prepareStatement("delete from " + option.getChangelogTable() + " where ID = ?")) {
+      stmt.setBigDecimal(1, id);
+      stmt.execute();
+      con.commit();
+    }
+  }
+}

--- a/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.jdbc.SqlRunner;
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.MigrationException;

--- a/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DatabaseOperation.java
@@ -17,15 +17,11 @@ package org.apache.ibatis.migration.operations;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
-import org.apache.ibatis.jdbc.SqlRunner;
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.MigrationException;
 import org.apache.ibatis.migration.options.DatabaseOperationOption;
@@ -34,11 +30,9 @@ public abstract class DatabaseOperation {
 
   protected void insertChangelog(Change change, Connection con, DatabaseOperationOption option) {
     try {
-      SqlRunner runner = new SqlRunner(con);
+      ChangelogOperation operation = new ChangelogOperation(con, option);
       change.setAppliedTimestamp(generateAppliedTimeStampAsString());
-      runner.insert("insert into " + option.getChangelogTable() + " (ID, APPLIED_AT, DESCRIPTION) values (?,?,?)",
-          change.getId(), change.getAppliedTimestamp(), change.getDescription());
-      con.commit();
+      operation.insert(change);
     } catch (SQLException e) {
       throw new MigrationException("Error querying last applied migration.  Cause: " + e, e);
     }
@@ -46,30 +40,16 @@ public abstract class DatabaseOperation {
 
   protected List<Change> getChangelog(Connection con, DatabaseOperationOption option) {
     try {
-      SqlRunner runner = new SqlRunner(con);
-      List<Map<String, Object>> changelog = runner
-          .selectAll("select ID, APPLIED_AT, DESCRIPTION from " + option.getChangelogTable() + " order by ID");
-      List<Change> changes = new ArrayList<Change>();
-      for (Map<String, Object> change : changelog) {
-        String id = change.get("ID") == null ? null : change.get("ID").toString();
-        String appliedAt = change.get("APPLIED_AT") == null ? null : change.get("APPLIED_AT").toString();
-        String description = change.get("DESCRIPTION") == null ? null : change.get("DESCRIPTION").toString();
-        changes.add(new Change(new BigDecimal(id), appliedAt, description));
-      }
-      return changes;
+      ChangelogOperation operation = new ChangelogOperation(con, option);
+      return operation.selectAll();
     } catch (SQLException e) {
       throw new MigrationException("Error querying last applied migration.  Cause: " + e, e);
     }
   }
 
   protected boolean changelogExists(Connection con, DatabaseOperationOption option) {
-    try {
-      SqlRunner runner = new SqlRunner(con);
-      runner.selectAll("select ID, APPLIED_AT, DESCRIPTION from " + option.getChangelogTable());
-      return true;
-    } catch (SQLException e) {
-      return false;
-    }
+    ChangelogOperation operation = new ChangelogOperation(con, option);
+    return operation.tableExists();
   }
 
   protected String checkSkippedOrMissing(List<Change> changesInDb, List<Change> migrations) {

--- a/src/main/java/org/apache/ibatis/migration/operations/DownOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DownOperation.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.ibatis.jdbc.SqlRunner;
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.ConnectionProvider;
 import org.apache.ibatis.migration.MigrationException;
@@ -119,8 +118,7 @@ public final class DownOperation extends DatabaseOperation {
   }
 
   protected void deleteChange(Connection con, Change change, DatabaseOperationOption option) throws SQLException {
-    SqlRunner runner = new SqlRunner(con);
-    runner.delete("delete from " + option.getChangelogTable() + " where ID = ?", change.getId());
-    con.commit();
+    ChangelogOperation operation = new ChangelogOperation(con, option);
+    operation.deleteById(change.getId());
   }
 }

--- a/src/main/java/org/apache/ibatis/migration/operations/DownOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/DownOperation.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.jdbc.SqlRunner;
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.ConnectionProvider;

--- a/src/main/java/org/apache/ibatis/migration/operations/PendingOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/PendingOperation.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.ConnectionProvider;
 import org.apache.ibatis.migration.MigrationException;

--- a/src/main/java/org/apache/ibatis/migration/operations/ScriptRunner.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/ScriptRunner.java
@@ -1,0 +1,328 @@
+/**
+ *    Copyright 2010-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.migration.operations;
+
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.Statement;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Clinton Begin
+ */
+public class ScriptRunner {
+
+  private static final String LINE_SEPARATOR = System.lineSeparator();
+
+  private static final String DEFAULT_DELIMITER = ";";
+
+  private static final Pattern DELIMITER_PATTERN = Pattern
+      .compile("^\\s*((--)|(//))?\\s*(//)?\\s*@DELIMITER\\s+([^\\s]+)", Pattern.CASE_INSENSITIVE);
+
+  private final Connection connection;
+
+  private boolean stopOnError;
+  private boolean throwWarning;
+  private boolean autoCommit;
+  private boolean sendFullScript;
+  private boolean removeCRs;
+  private boolean escapeProcessing = true;
+
+  private PrintWriter logWriter = new PrintWriter(System.out);
+  private PrintWriter errorLogWriter = new PrintWriter(System.err);
+
+  private String delimiter = DEFAULT_DELIMITER;
+  private boolean fullLineDelimiter;
+
+  public ScriptRunner(Connection connection) {
+    this.connection = connection;
+  }
+
+  public void setStopOnError(boolean stopOnError) {
+    this.stopOnError = stopOnError;
+  }
+
+  public void setThrowWarning(boolean throwWarning) {
+    this.throwWarning = throwWarning;
+  }
+
+  public void setAutoCommit(boolean autoCommit) {
+    this.autoCommit = autoCommit;
+  }
+
+  public void setSendFullScript(boolean sendFullScript) {
+    this.sendFullScript = sendFullScript;
+  }
+
+  public void setRemoveCRs(boolean removeCRs) {
+    this.removeCRs = removeCRs;
+  }
+
+  /**
+   * Sets the escape processing.
+   *
+   * @param escapeProcessing
+   *          the new escape processing
+   * @since 3.1.1
+   */
+  public void setEscapeProcessing(boolean escapeProcessing) {
+    this.escapeProcessing = escapeProcessing;
+  }
+
+  public void setLogWriter(PrintWriter logWriter) {
+    this.logWriter = logWriter;
+  }
+
+  public void setErrorLogWriter(PrintWriter errorLogWriter) {
+    this.errorLogWriter = errorLogWriter;
+  }
+
+  public void setDelimiter(String delimiter) {
+    this.delimiter = delimiter;
+  }
+
+  public void setFullLineDelimiter(boolean fullLineDelimiter) {
+    this.fullLineDelimiter = fullLineDelimiter;
+  }
+
+  public void runScript(Reader reader) {
+    setAutoCommit();
+
+    try {
+      if (sendFullScript) {
+        executeFullScript(reader);
+      } else {
+        executeLineByLine(reader);
+      }
+    } finally {
+      rollbackConnection();
+    }
+  }
+
+  private void executeFullScript(Reader reader) {
+    StringBuilder script = new StringBuilder();
+    try {
+      BufferedReader lineReader = new BufferedReader(reader);
+      String line;
+      while ((line = lineReader.readLine()) != null) {
+        script.append(line);
+        script.append(LINE_SEPARATOR);
+      }
+      String command = script.toString();
+      println(command);
+      executeStatement(command);
+      commitConnection();
+    } catch (Exception e) {
+      String message = "Error executing: " + script + ".  Cause: " + e;
+      printlnError(message);
+      throw new RuntimeException(message, e);
+    }
+  }
+
+  private void executeLineByLine(Reader reader) {
+    StringBuilder command = new StringBuilder();
+    try {
+      BufferedReader lineReader = new BufferedReader(reader);
+      String line;
+      while ((line = lineReader.readLine()) != null) {
+        handleLine(command, line);
+      }
+      commitConnection();
+      checkForMissingLineTerminator(command);
+    } catch (Exception e) {
+      String message = "Error executing: " + command + ".  Cause: " + e;
+      printlnError(message);
+      throw new RuntimeException(message, e);
+    }
+  }
+
+  /**
+   * @deprecated Since 3.5.4, this method is deprecated. Please close the {@link Connection} outside of this class.
+   */
+  @Deprecated
+  public void closeConnection() {
+    try {
+      connection.close();
+    } catch (Exception e) {
+      // ignore
+    }
+  }
+
+  private void setAutoCommit() {
+    try {
+      if (autoCommit != connection.getAutoCommit()) {
+        connection.setAutoCommit(autoCommit);
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException("Could not set AutoCommit to " + autoCommit + ". Cause: " + t, t);
+    }
+  }
+
+  private void commitConnection() {
+    try {
+      if (!connection.getAutoCommit()) {
+        connection.commit();
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException("Could not commit transaction. Cause: " + t, t);
+    }
+  }
+
+  private void rollbackConnection() {
+    try {
+      if (!connection.getAutoCommit()) {
+        connection.rollback();
+      }
+    } catch (Throwable t) {
+      // ignore
+    }
+  }
+
+  private void checkForMissingLineTerminator(StringBuilder command) {
+    if (command != null && command.toString().trim().length() > 0) {
+      throw new RuntimeException("Line missing end-of-line terminator (" + delimiter + ") => " + command);
+    }
+  }
+
+  private void handleLine(StringBuilder command, String line) throws SQLException {
+    String trimmedLine = line.trim();
+    if (lineIsComment(trimmedLine)) {
+      Matcher matcher = DELIMITER_PATTERN.matcher(trimmedLine);
+      if (matcher.find()) {
+        delimiter = matcher.group(5);
+      }
+      println(trimmedLine);
+    } else if (commandReadyToExecute(trimmedLine)) {
+      command.append(line, 0, line.lastIndexOf(delimiter));
+      command.append(LINE_SEPARATOR);
+      println(command);
+      executeStatement(command.toString());
+      command.setLength(0);
+    } else if (trimmedLine.length() > 0) {
+      command.append(line);
+      command.append(LINE_SEPARATOR);
+    }
+  }
+
+  private boolean lineIsComment(String trimmedLine) {
+    return trimmedLine.startsWith("//") || trimmedLine.startsWith("--");
+  }
+
+  private boolean commandReadyToExecute(String trimmedLine) {
+    // issue #561 remove anything after the delimiter
+    return !fullLineDelimiter && trimmedLine.contains(delimiter) || fullLineDelimiter && trimmedLine.equals(delimiter);
+  }
+
+  private void executeStatement(String command) throws SQLException {
+    Statement statement = connection.createStatement();
+    try {
+      statement.setEscapeProcessing(escapeProcessing);
+      String sql = command;
+      if (removeCRs) {
+        sql = sql.replace("\r\n", "\n");
+      }
+      try {
+        boolean hasResults = statement.execute(sql);
+        while (!(!hasResults && statement.getUpdateCount() == -1)) {
+          checkWarnings(statement);
+          printResults(statement, hasResults);
+          hasResults = statement.getMoreResults();
+        }
+      } catch (SQLWarning e) {
+        throw e;
+      } catch (SQLException e) {
+        if (stopOnError) {
+          throw e;
+        } else {
+          String message = "Error executing: " + command + ".  Cause: " + e;
+          printlnError(message);
+        }
+      }
+    } finally {
+      try {
+        statement.close();
+      } catch (Exception ignored) {
+        // Ignore to workaround a bug in some connection pools
+        // (Does anyone know the details of the bug?)
+      }
+    }
+  }
+
+  private void checkWarnings(Statement statement) throws SQLException {
+    if (!throwWarning) {
+      return;
+    }
+    // In Oracle, CREATE PROCEDURE, FUNCTION, etc. returns warning
+    // instead of throwing exception if there is compilation error.
+    SQLWarning warning = statement.getWarnings();
+    if (warning != null) {
+      throw warning;
+    }
+  }
+
+  private void printResults(Statement statement, boolean hasResults) {
+    if (!hasResults) {
+      return;
+    }
+    try (ResultSet rs = statement.getResultSet()) {
+      ResultSetMetaData md = rs.getMetaData();
+      int cols = md.getColumnCount();
+      for (int i = 0; i < cols; i++) {
+        String name = md.getColumnLabel(i + 1);
+        print(name + "\t");
+      }
+      println("");
+      while (rs.next()) {
+        for (int i = 0; i < cols; i++) {
+          String value = rs.getString(i + 1);
+          print(value + "\t");
+        }
+        println("");
+      }
+    } catch (SQLException e) {
+      printlnError("Error printing results: " + e.getMessage());
+    }
+  }
+
+  private void print(Object o) {
+    if (logWriter != null) {
+      logWriter.print(o);
+      logWriter.flush();
+    }
+  }
+
+  private void println(Object o) {
+    if (logWriter != null) {
+      logWriter.println(o);
+      logWriter.flush();
+    }
+  }
+
+  private void printlnError(Object o) {
+    if (errorLogWriter != null) {
+      errorLogWriter.println(o);
+      errorLogWriter.flush();
+    }
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/migration/operations/UpOperation.java
+++ b/src/main/java/org/apache/ibatis/migration/operations/UpOperation.java
@@ -23,8 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.ibatis.jdbc.RuntimeSqlException;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.ConnectionProvider;
 import org.apache.ibatis.migration.MigrationException;
@@ -108,7 +106,7 @@ public final class UpOperation extends DatabaseOperation {
         }
         println(printStream, skippedOrMissing);
         return this;
-      } catch (RuntimeSqlException e) {
+      } catch (Exception e) {
         onAbortScriptReader = migrationsLoader.getOnAbortReader();
         if (onAbortScriptReader != null) {
           println(printStream);

--- a/src/test/java/org/apache/ibatis/migration/MigratorTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigratorTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2019 the original author or authors.
+ *    Copyright 2010-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.PrintWriter;
 import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Scanner;
 
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.SqlRunner;
 import org.apache.ibatis.migration.utils.TestUtil;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -117,12 +117,11 @@ public class MigratorTest {
   }
 
   private void assertAuthorEmailContainsPlaceholder() throws Exception {
-    try (final Connection conn = TestUtil.getConnection(env)) {
-      final SqlRunner executor = new SqlRunner(conn);
-      final Map<String, Object> author = executor.selectOne("select * from author where id = ?", 1);
-      assertNotNull(author);
-      assertNotNull(author.get("EMAIL"));
-      assertEquals("jim@${url}", author.get("EMAIL"));
+    try (final Connection conn = TestUtil.getConnection(env);
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("select EMAIL from author where id = 1")) {
+      assertTrue(rs.next());
+      assertEquals("jim@${url}", rs.getString("EMAIL"));
     }
   }
 


### PR DESCRIPTION
Most importantly, Migrations maintains its own version of `ScriptRunner` from now on.
References to other core classes are also removed except `Resources` and `ResolverUtil`.
There should be no difference in functionality and there are some improvements in efficiency.