### PR TITLE
Omit unnecessary DELETE statement when generating UNDO script

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -60,6 +60,7 @@ import org.apache.ibatis.migration.utils.Util;
 
 public abstract class BaseCommand implements Command {
   private static final String DATE_FORMAT = "yyyyMMddHHmmss";
+  protected static final String DESC_CREATE_CHANGELOG = "create changelog";
 
   private ClassLoader driverClassLoader;
   private Environment environment;

--- a/src/main/java/org/apache/ibatis/migration/commands/InitializeCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/InitializeCommand.java
@@ -46,7 +46,7 @@ public final class InitializeCommand extends BaseCommand {
     copyResourceTo("org/apache/ibatis/migration/template_environment.properties", environmentFile());
     copyResourceTo("org/apache/ibatis/migration/template_bootstrap.sql", Util.file(scriptPath, "bootstrap.sql"));
     copyResourceTo("org/apache/ibatis/migration/template_changelog.sql",
-        Util.file(scriptPath, getNextIDAsString() + "_create_changelog.sql"));
+        Util.file(scriptPath, getNextIDAsString() + "_" + DESC_CREATE_CHANGELOG.replace(' ', '_') +".sql"));
     copyResourceTo("org/apache/ibatis/migration/template_migration.sql",
         Util.file(scriptPath, getNextIDAsString() + "_first_migration.sql"), new Properties() {
           {

--- a/src/main/java/org/apache/ibatis/migration/commands/ScriptCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/ScriptCommand.java
@@ -77,7 +77,8 @@ public final class ScriptCommand extends BaseCommand {
       if (undo) {
         Collections.reverse(migrations);
       }
-      for (Change change : migrations) {
+      for (int i = 0; i < migrations.size(); i++) {
+        Change change = migrations.get(i);
         if (shouldRun(change, v1, v2, scriptPending || scriptPendingUndo)) {
           printStream.println("-- " + change.getFilename());
           Reader migrationReader = getMigrationLoader().getScriptReader(change, undo);
@@ -88,7 +89,11 @@ public final class ScriptCommand extends BaseCommand {
           }
           printStream.println();
           printStream.println();
-          printStream.println(undo ? generateVersionDelete(change) : generateVersionInsert(change));
+          if (!undo) {
+            printStream.println(generateVersionInsert(change));
+          } else if (i + 1 < migrations.size() || !DESC_CREATE_CHANGELOG.equals(change.getDescription())) {
+            printStream.println(generateVersionDelete(change));
+          }
           printStream.println();
         }
       }

--- a/src/test/java/org/apache/ibatis/migration/MigratorTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigratorTest.java
@@ -274,6 +274,7 @@ public class MigratorTest {
     assertFalse(output.contains("20080827200213"));
     assertFalse(output.contains("20080827200214"));
     assertFalse(output.contains("20080827200216"));
+    assertFalse(output.contains("DELETE FROM CHANGELOG WHERE ID = 20080827200210;"));
     assertTrue(output.contains("-- @UNDO"));
   }
 


### PR DESCRIPTION
When generating 'undo' script, omit the SQL deleting changelog entry for 'create changelog' migration
The logic is: the last migration's description is 'create changelog', skip printing the DELETE statement.
Note that 'the last migration' means the last in the specified range of migrations.

Should fix #201