### PR TITLE
[jdk18+] Add support using security manager to allow builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        java: [8, 11, 17]
+        java: [8, 11, 17, 18, 19-ea]
         distribution: ['zulu']
       fail-fast: false
       max-parallel: 4

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,15 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>security-manager</id>
+      <activation>
+        <jdk>[18,)</jdk>
+      </activation>
+      <properties>
+        <argLine>-Djava.security.manager=allow</argLine>
+      </properties>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
deprecated and forced off by default, turn back on to verify build