### PR TITLE
Fixes #225: init/info fail when non-existent base path is passed

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/CommandLine.java
+++ b/src/main/java/org/apache/ibatis/migration/CommandLine.java
@@ -39,7 +39,8 @@ public class CommandLine {
   public void execute() {
     final SelectedOptions selectedOptions = parse(args);
     try {
-      if (!validOptions(selectedOptions) || selectedOptions.needsHelp()) {
+      // order is important as if !needsHelp then a valid command is required but, not vice-versa
+      if (selectedOptions.needsHelp() || !validOptions(selectedOptions)) {
         printUsage();
       } else {
         runCommand(selectedOptions);

--- a/src/main/java/org/apache/ibatis/migration/CommandLine.java
+++ b/src/main/java/org/apache/ibatis/migration/CommandLine.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2021 the original author or authors.
+ *    Copyright 2010-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.io.PrintStream;
 import java.util.Date;
 
 import org.apache.ibatis.migration.commands.Command;
+import org.apache.ibatis.migration.commands.Commands;
 import org.apache.ibatis.migration.options.Options;
 import org.apache.ibatis.migration.options.SelectedOptions;
 import org.apache.ibatis.migration.utils.Util;
@@ -114,8 +115,9 @@ public class CommandLine {
       console.printf("No command specified.%n");
       return false;
     }
-
-    return validBasePath(selectedOptions.getPaths().getBasePath());
+    String cmd = selectedOptions.getCommand().toUpperCase();
+    return Commands.INIT.name().startsWith(cmd) || Commands.INFO.name().startsWith(cmd)
+        || validBasePath(selectedOptions.getPaths().getBasePath());
   }
 
   private boolean validBasePath(File basePath) {

--- a/src/test/java/org/apache/ibatis/migration/MigratorTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigratorTest.java
@@ -329,6 +329,7 @@ public class MigratorTest {
     assertEquals(3, scriptPath.list().length);
     Migrator.main(TestUtil.args("--path=" + basePath.getAbsolutePath(), "new", "test new migration"));
     assertEquals(4, scriptPath.list().length);
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
   @Test
@@ -344,6 +345,7 @@ public class MigratorTest {
     File newMigration = new File(
         basePath.getCanonicalPath() + File.separator + "scripts" + File.separator + "003_new_migration.sql");
     assertTrue(newMigration.exists());
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
   @Test
@@ -371,6 +373,7 @@ public class MigratorTest {
       }
     }
     templatePath.delete();
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
   @Test
@@ -387,6 +390,7 @@ public class MigratorTest {
     Migrator.main(TestUtil.args("--path=" + basePath.getAbsolutePath(), "new", "test new migration", "--template="));
     assertEquals(4, scriptPath.list().length);
     templatePath.delete();
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
   @Test
@@ -405,6 +409,7 @@ public class MigratorTest {
     assertEquals(4, scriptPath.list().length);
     assertTrue(output
         .contains("Your migrations configuration did not find your custom template.  Using the default template."));
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
   @Test
@@ -416,6 +421,7 @@ public class MigratorTest {
     });
     assertFalse(output.contains("Initializing:"));
     assertNotNull(basePath.list());
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
   @Test
@@ -427,6 +433,7 @@ public class MigratorTest {
     });
     assertTrue(output.contains(ConsoleColors.GREEN + "SUCCESS"));
     assertNotNull(basePath.list());
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
   @Test
@@ -440,6 +447,7 @@ public class MigratorTest {
       assertEquals(1, exitCode);
     });
     assertTrue(output.contains(ConsoleColors.RED + "FAILURE"));
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/migration/MigratorTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigratorTest.java
@@ -474,4 +474,29 @@ public class MigratorTest {
     assertFalse(output.contains("null"), output);
   }
 
+  @Test
+  void testInfoWithNonExistentBasePath() throws Exception {
+    File baseDir = TestUtil.getTempDir();
+    assertTrue(baseDir.delete()); // remove empty dir
+    assertFalse(baseDir.exists(), "directory does not exist");
+    String output = SystemLambda.tapSystemOut(() -> {
+      Migrator.main(TestUtil.args("info", "--path=" + baseDir.getAbsolutePath()));
+    });
+    assertFalse(output.contains("Migrations path must be a directory"), "base path not required for info");
+    assertFalse(output.contains("null"), output);
+  }
+
+  @Test
+  void testInitWithNonExistentBasePath() throws Exception {
+    File baseDir = TestUtil.getTempDir();
+    assertTrue(baseDir.delete()); // remove empty dir
+    assertFalse(baseDir.exists(), "directory does not exist");
+    String output = SystemLambda
+        .tapSystemOut(() -> Migrator.main(TestUtil.args("init", "--path=" + baseDir.getAbsolutePath())));
+    assertFalse(output.contains("Migrations path must be a directory"), output);
+    assertTrue(new File(baseDir, "README").exists(), "README created");
+    assertTrue(new File(baseDir, "environments").isDirectory(), "environments directory created");
+    assertTrue(TestUtil.deleteDirectory(baseDir), "delete temp dir");
+  }
+
 }

--- a/src/test/java/org/apache/ibatis/migration/hook/NewHookTest.java
+++ b/src/test/java/org/apache/ibatis/migration/hook/NewHookTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2021 the original author or authors.
+ *    Copyright 2010-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ class NewHookTest {
     assertTrue(output.contains("Description is valid."));
     assertTrue(output.contains("Renamed 03_create_table1_JIRA-123.sql to 03_create_table1_JIRA123.sql"));
     assertTrue(new File(scriptPath, "03_create_table1_JIRA123.sql").exists());
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete test dir");
   }
 
   @Test
@@ -65,6 +66,7 @@ class NewHookTest {
     });
     assertTrue(output.contains("FAILURE"));
     assertEquals(3, scriptPath.list().length);
+    assertTrue(TestUtil.deleteDirectory(basePath), "delete test dir");
   }
 
   protected File initBaseDir() throws IOException {

--- a/src/test/java/org/apache/ibatis/migration/utils/TestUtil.java
+++ b/src/test/java/org/apache/ibatis/migration/utils/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2021 the original author or authors.
+ *    Copyright 2010-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -57,5 +57,15 @@ public class TestUtil {
     assertTrue(f.isDirectory());
     f.deleteOnExit();
     return f;
+  }
+
+  public static boolean deleteDirectory(File dir) throws IOException {
+    boolean result = dir.exists();
+    if (result) {
+      for (File f : dir.listFiles()) {
+        result = result && (f.isDirectory() ? deleteDirectory(f) : f.delete());
+      }
+    }
+    return result && dir.delete();
   }
 }


### PR DESCRIPTION
Fix for #225 

* init must be accept non-existent base paths and create it if necessary
* info does not require a base path
* Also fixes issue where the tests litter the `/tmp` folder with `migration*` folders which do not get cleaned up as the `File.delete()` can only delete empty directories