### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/io/DefaultVFS.java
+++ b/src/main/java/org/apache/ibatis/migration/io/DefaultVFS.java
@@ -80,7 +80,16 @@ public class DefaultVFS extends VFS {
                 if (log.isLoggable(Level.FINER)) {
                   log.log(Level.FINER, "Jar entry: " + entry.getName());
                 }
-                children.add(entry.getName());
+                String entryName = entry.getName();
+                File entryFile = new File(path, entryName).getCanonicalFile();
+                File baseDir = new File(path).getCanonicalFile();
+                if (!entryFile.toPath().startsWith(baseDir.toPath())) {
+                  if (log.isLoggable(Level.WARNING)) {
+                    log.log(Level.WARNING, "Skipping potentially unsafe entry: " + entryName);
+                  }
+                  continue;
+                }
+                children.add(entryName);
               }
             }
           } else {


### PR DESCRIPTION
Potential fix for [https://github.com/mybatis/migrations/security/code-scanning/1](https://github.com/mybatis/migrations/security/code-scanning/1)

To fix the issue, we need to validate the `entry.getName()` value to ensure it does not contain directory traversal sequences (`../`) or absolute paths. This can be achieved by normalizing the constructed path and verifying that it remains within the intended base directory. Specifically:
1. Use `java.nio.file.Path` to construct and normalize the path.
2. Check that the normalized path starts with the intended base directory.
3. If the validation fails, skip the entry or throw an exception.

The fix will be applied in the `listResources` method (or equivalent logic) where `entry.getName()` is processed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
