### PR TITLE
Compatibility with Java 24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2010-2024 the original author or authors.
+       Copyright 2010-2025 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -206,7 +206,7 @@
     <profile>
       <id>security-manager</id>
       <activation>
-        <jdk>[18,)</jdk>
+        <jdk>[18,24)</jdk>
       </activation>
       <properties>
         <argLine>-Djava.security.manager=allow</argLine>

--- a/src/test/java/org/apache/ibatis/migration/MigratorTest.java
+++ b/src/test/java/org/apache/ibatis/migration/MigratorTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 
 import uk.org.webcompere.systemstubs.SystemStubs;
 
@@ -307,6 +308,7 @@ class MigratorTest {
     assertTrue(output.contains("-- @UNDO"));
   }
 
+  @EnabledForJreRange(maxVersion = 23)
   @Test
   void shouldScriptCommandFailIfSameVersion() throws Exception {
     String output = SystemStubs.tapSystemOut(() -> {
@@ -435,6 +437,7 @@ class MigratorTest {
     assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
+  @EnabledForJreRange(maxVersion = 23)
   @Test
   void shouldColorizeFailureOutputIfColorOptionEnabled() throws Throwable {
     System.setProperty("migrationsHome", TestUtil.getTempDir().getAbsolutePath());
@@ -449,6 +452,7 @@ class MigratorTest {
     assertTrue(TestUtil.deleteDirectory(basePath), "delete temp dir");
   }
 
+  @EnabledForJreRange(maxVersion = 23)
   @Test
   void shouldShowErrorOnMissingChangelog() throws Throwable {
     // gh-220

--- a/src/test/java/org/apache/ibatis/migration/hook/NewHookTest.java
+++ b/src/test/java/org/apache/ibatis/migration/hook/NewHookTest.java
@@ -33,6 +33,7 @@ import org.apache.ibatis.migration.io.Resources;
 import org.apache.ibatis.migration.utils.TestUtil;
 import org.apache.ibatis.migration.utils.Util;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 
 import uk.org.webcompere.systemstubs.SystemStubs;
 
@@ -55,6 +56,7 @@ class NewHookTest {
     assertTrue(TestUtil.deleteDirectory(basePath), "delete test dir");
   }
 
+  @EnabledForJreRange(maxVersion = 23)
   @Test
   void shouldNotCreateFileWhenBeforeHookThrowsException() throws Throwable {
     File basePath = initBaseDir();


### PR DESCRIPTION
`-Djava.security.manager=allow` no longer works.

system-stubs's System.exit does not support Java 24.
https://github.com/webcompere/system-stubs/issues/37

junit5-system-exit might work, but it does not capture standard out/error (I think).
https://github.com/tginsberg/junit5-system-exit/
